### PR TITLE
to cleanup all created resources, not only kube-ovn namespace.

### DIFF
--- a/dist/images/cleanup.sh
+++ b/dist/images/cleanup.sh
@@ -6,7 +6,8 @@ kubectl patch svc -n kube-ovn ovn-nb --type='json' -p '[{"op": "replace", "path"
 kubectl patch svc -n kube-ovn ovn-sb --type='json' -p '[{"op": "replace", "path": "/metadata/finalizers", "value": []}]' || true
 
 # Delete Kube-OVN components
-kubectl delete ns kube-ovn
+kubectl delete -f https://raw.githubusercontent.com/alauda/kube-ovn/master/yamls/ovn.yaml
+kubectl delete -f https://raw.githubusercontent.com/alauda/kube-ovn/master/yamls/kube-ovn.yaml
 
 # Remove annotations in namespaces and nodes
 kubectl annotate no --all ovn.kubernetes.io/cidr-


### PR DESCRIPTION
There are some resources that are not being deleted, such as role, sa, rolebinding and so on.
So delete kube-ovn namespace not enough.
