### PR TITLE
fix: network unreachable when add egress qos for pod

### DIFF
--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -116,6 +116,11 @@ func configureHostNic(nicName string, macAddr net.HardwareAddr) error {
 	if err != nil {
 		return fmt.Errorf("can not set host nic %s up %v", nicName, err)
 	}
+	err = netlink.LinkSetTxQLen(hostLink, 1000)
+	if err != nil {
+		return fmt.Errorf("can not set host nic %s qlen %v", nicName, err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
when add egress qos for pod, the pod network is unreachable.
through research, the container's virtual nic's qlen is 0 is
the root reason. so set the nic's qlen to 1000(default for linux)
when create pod.