### PR TITLE
use short kubernetes.default service

### DIFF
--- a/pkg/pinger/config.go
+++ b/pkg/pinger/config.go
@@ -34,7 +34,7 @@ func ParseFlags() (*Configuration, error) {
 		argDaemonSetName      = pflag.String("ds-name", "kube-ovn-pinger", "kube-ovn-pinger daemonset name")
 		argInterval           = pflag.Int("interval", 5, "interval seconds between consecutive pings")
 		argMode               = pflag.String("mode", "server", "server or job Mode")
-		argDns                = pflag.String("dns", "kubernetes.default.svc.cluster.local", "check dns from pod")
+		argDns                = pflag.String("dns", "kubernetes.default", "check dns from pod")
 	)
 
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)


### PR DESCRIPTION
Use the short name kubernetes.default which is always resolvable instead of the fqdn which may be different from cluster to cluster.
