### PR TITLE
fix: cluster mode db will generate lots listen error log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,17 @@ kind-init:
 	kubectl apply -f yamls/ovn.yaml
 	kubectl apply -f yamls/kube-ovn.yaml
 
+kind-init-ha:
+	kind delete cluster --name=kube-ovn
+	kind create cluster --config yamls/kind.yaml --name kube-ovn
+	@for role in ${ROLES} ; do \
+		kind load docker-image --name kube-ovn ${REGISTRY}/kube-ovn-$$role:${RELEASE_TAG}; \
+	done
+	kubectl label node --all kube-ovn/role=master
+	kubectl apply -f yamls/crd.yaml
+	kubectl apply -f yamls/ovn-ha.yaml
+	kubectl apply -f yamls/kube-ovn.yaml
+
 kind-reload:
 	@for role in ${ROLES} ; do \
 		kind load docker-image ${REGISTRY}/kube-ovn-$$role:${RELEASE_TAG}; \

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -58,11 +58,6 @@ else
             --ovn-northd-nb-db=$(gen_conn_str 6641) \
             --ovn-northd-sb-db=$(gen_conn_str 6642) \
             start_northd
-
-        # ovn-nb and ovn-sb listen on tcp ports for ovn-controller to connect
-        ovn-nbctl set-connection ptcp:"${DB_NB_PORT}":["${DB_NB_ADDR}"]
-        ovn-sbctl set-connection ptcp:"${DB_SB_PORT}":["${DB_SB_ADDR}"]
-        ovn-sbctl set Connection . inactivity_probe=0
     else
         while ! nc -z "${nb_leader_ip}" "${DB_NB_PORT}" >/dev/null;
         do

--- a/yamls/ovn-ha.yaml
+++ b/yamls/ovn-ha.yaml
@@ -1,0 +1,323 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-ovn
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ovn-config
+  namespace: kube-ovn
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovn
+  namespace: kube-ovn
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.k8s.io/system-only: "true"
+  name: system:ovn
+rules:
+  - apiGroups:
+      - "kubeovn.io"
+    resources:
+      - subnets
+      - subnets/status
+      - ips
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - namespaces
+      - nodes
+      - configmaps
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - ""
+      - networking.k8s.io
+      - apps
+    resources:
+      - networkpolicies
+      - services
+      - endpoints
+      - statefulsets
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovn
+roleRef:
+  name: system:ovn
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: ovn
+    namespace: kube-ovn
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ovn-nb
+  namespace: kube-ovn
+spec:
+  ports:
+    - name: ovn-nb
+      protocol: TCP
+      port: 6641
+      targetPort: 6641
+  type: ClusterIP
+  selector:
+    app: ovn-central
+    ovn-nb-leader: "true"
+  sessionAffinity: None
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ovn-sb
+  namespace: kube-ovn
+spec:
+  ports:
+    - name: ovn-sb
+      protocol: TCP
+      port: 6642
+      targetPort: 6642
+  type: ClusterIP
+  selector:
+    app: ovn-central
+    ovn-sb-leader: "true"
+  sessionAffinity: None
+
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ovn-central
+  namespace: kube-ovn
+  annotations:
+    kubernetes.io/description: |
+      OVN components: northd, nb and sb.
+spec:
+  replicas: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 0%
+      maxUnavailable: 100%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ovn-central
+  template:
+    metadata:
+      labels:
+        app: ovn-central
+        component: network
+        type: infra
+    spec:
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: ovn-central
+              topologyKey: kubernetes.io/hostname
+      serviceAccountName: ovn
+      hostNetwork: true
+      containers:
+        - name: ovn-central
+          image: "index.alauda.cn/alaudak8s/kube-ovn-db:v1.0.0-pre"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add: ["SYS_NICE"]
+          env:
+            - name: NODE_IPS
+              value: 172.17.0.2,172.17.0.3,172.17.0.4
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            requests:
+              cpu: 500m
+              memory: 300Mi
+          volumeMounts:
+            - mountPath: /run/openvswitch
+              name: host-run-ovs
+            - mountPath: /var/run/openvswitch
+              name: host-run-ovs
+            - mountPath: /sys
+              name: host-sys
+              readOnly: true
+            - mountPath: /etc/openvswitch
+              name: host-config-openvswitch
+            - mountPath: /var/log/openvswitch
+              name: host-log
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - /root/ovn-is-leader.sh
+            periodSeconds: 3
+          livenessProbe:
+            exec:
+              command:
+              - sh
+              - /root/ovn-healthcheck.sh
+            initialDelaySeconds: 30
+            periodSeconds: 7
+            failureThreshold: 5
+      nodeSelector:
+        beta.kubernetes.io/os: "linux"
+        kube-ovn/role: "master"
+      volumes:
+        - name: host-run-ovs
+          hostPath:
+            path: /run/openvswitch
+        - name: host-sys
+          hostPath:
+            path: /sys
+        - name: host-config-openvswitch
+          hostPath:
+            path: /etc/origin/openvswitch
+        - name: host-log
+          hostPath:
+            path: /var/log/openvswitch
+
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovs-ovn
+  namespace: kube-ovn
+  annotations:
+    kubernetes.io/description: |
+      This daemon set launches the openvswitch daemon.
+spec:
+  selector:
+    matchLabels:
+      app: ovs
+  updateStrategy:
+    type: OnDelete
+  template:
+    metadata:
+      labels:
+        app: ovs
+        component: network
+        type: infra
+    spec:
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      serviceAccountName: ovn
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: openvswitch
+          image: "index.alauda.cn/alaudak8s/kube-ovn-node:v1.0.0-pre"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 0
+            privileged: true
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: host-modules
+              readOnly: true
+            - mountPath: /run/openvswitch
+              name: host-run-ovs
+            - mountPath: /var/run/openvswitch
+              name: host-run-ovs
+            - mountPath: /sys
+              name: host-sys
+              readOnly: true
+            - mountPath: /etc/openvswitch
+              name: host-config-openvswitch
+            - mountPath: /var/log/openvswitch
+              name: host-log
+          readinessProbe:
+            exec:
+              command:
+              - sh
+              - /root/ovs-healthcheck.sh
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+              - sh
+              - /root/ovs-healthcheck.sh
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 200m
+              memory: 300Mi
+            limits:
+              cpu: 1000m
+              memory: 800Mi
+      nodeSelector:
+        beta.kubernetes.io/os: "linux"
+      volumes:
+        - name: host-modules
+          hostPath:
+            path: /lib/modules
+        - name: host-run-ovs
+          hostPath:
+            path: /run/openvswitch
+        - name: host-sys
+          hostPath:
+            path: /sys
+        - name: host-config-openvswitch
+          hostPath:
+            path: /etc/origin/openvswitch
+        - name: host-log
+          hostPath:
+            path: /var/log/openvswitch


### PR DESCRIPTION
```bash
2019-12-06T07:27:32.274Z|00059|socket_util|ERR|Dropped 8926 log messages in last 60 seconds (most recently, 0 seconds ago) due to excessive rate
2019-12-06T07:27:32.274Z|00060|socket_util|ERR|6641:[::]: bind: Address already in use
2019-12-06T07:27:32.274Z|00061|ovsdb_jsonrpc_server|ERR|Dropped 8926 log messages in last 60 seconds (most recently, 0 seconds ago) due to excessive rate
2019-12-06T07:27:32.274Z|00062|ovsdb_jsonrpc_server|ERR|ptcp:6641:[::]: listen failed: Address already in use
2019-12-06T07:28:32.285Z|00067|socket_util|ERR|Dropped 6283 log messages in last 60 seconds (most recently, 0 seconds ago) due to excessive rate
2019-12-06T07:28:32.285Z|00068|socket_util|ERR|6641:[::]: bind: Address already in use
2019-12-06T07:28:32.285Z|00069|ovsdb_jsonrpc_server|ERR|Dropped 6283 log messages in last 60 seconds (most recently, 0 seconds ago) due to excessive rate
2019-12-06T07:28:32.285Z|00070|ovsdb_jsonrpc_server|ERR|ptcp:6641:[::]: listen failed: Address already in use
2019-12-06T07:29:32.285Z|00073|socket_util|ERR|Dropped 4440 log messages in last 60 seconds (most recently, 0 seconds ago) due to excessive rate
2019-12-06T07:29:32.285Z|00074|socket_util|ERR|6641:[::]: bind: Address already in use
2019-12-06T07:29:32.285Z|00075|ovsdb_jsonrpc_server|ERR|Dropped 4440 log messages in last 60 seconds (most recently, 0 seconds ago) due to excessive rate
2019-12-06T07:29:32.285Z|00076|ovsdb_jsonrpc_server|ERR|ptcp:6641:[::]: listen failed: Address already in use
```