### PR TITLE
fix: do not add unallocated pod to port-group

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"github.com/alauda/kube-ovn/pkg/util"
 	"reflect"
 	"strings"
 
@@ -389,7 +390,7 @@ func (c *Controller) fetchSelectedPorts(namespace string, selector *metav1.Label
 
 	ports := make([]string, 0, len(pods))
 	for _, pod := range pods {
-		if !pod.Spec.HostNetwork {
+		if !pod.Spec.HostNetwork && pod.Annotations[util.AllocatedAnnotation] == "true" {
 			ports = append(ports, fmt.Sprintf("%s.%s", pod.Name, pod.Namespace))
 		}
 	}


### PR DESCRIPTION
E1216 06:32:23.551067       1 network_policy.go:99] error syncing 'src/default-deny-all': ovn-nbctl: perf-gp989.src: port name not found