### PR TITLE
Containerize OVS-DPDK, for issue 104

### DIFF
--- a/dist/images/Dockerfile.dpdk
+++ b/dist/images/Dockerfile.dpdk
@@ -1,0 +1,84 @@
+FROM centos:7
+
+ENV PYTHONDONTWRITEBYTECODE yes
+
+RUN yum install -y wget \
+        numactl-devel \
+        kernel-devel \
+        libpcap-devel \
+        libmnl-devel \
+        libibumad \
+        libibverbs-devel \
+        libibverbs \
+        libmlx5 \
+        libibverbs-utils \
+        dpdk-devel
+
+RUN yum groupinstall -y 'Development Tools'
+
+RUN yum install -y  \
+        PyYAML bind-utils \
+        openssl \
+        numactl-libs \
+        firewalld-filesystem \
+        libpcap \
+        hostname \
+        iproute strace socat nc \
+        unbound unbound-devel && \
+        yum clean all
+
+ENV DPDK_VERSION=18.11.2
+ENV DPDK_DIR=/usr/src/dpdk-stable-$DPDK_VERSION
+ENV DPDK_TARGET=x86_64-native-linuxapp-gcc
+ENV DPDK_BUILD=$DPDK_DIR/$DPDK_TARGET
+ENV OVS_VERSION=2.11.4
+ENV OVS_SUBVERSION=2
+
+# Note - Change KERNEL_MOD to your host version under /lib/modules/
+#        For this reason I'm not sure built image will be portable
+#        User must build locally against their local version
+ENV KERNEL_MOD 3.10.0-1062.9.1.el7.x86_64
+
+RUN mkdir /lib/modules/$KERNEL_MOD/
+RUN ln -sfn /usr/src/kernels/$KERNEL_MOD /lib/modules/$KERNEL_MOD/build
+
+RUN cd /usr/src/ && \
+    wget http://fast.dpdk.org/rel/dpdk-$DPDK_VERSION.tar.xz && \
+    tar xf dpdk-$DPDK_VERSION.tar.xz && \
+    rm -f dpdk-$DPDK_VERSION.tar.xz
+
+
+RUN cd $DPDK_DIR && \
+    make install T=$DPDK_TARGET DESTDIR=install
+
+# Note - Could not find an OVS 2.11.4 tar gz on OVS releases, only 2.11.1
+#        The RPMs on github.com/alauda/ovs/releases are OVS 2.11.4, there is no 2.11.1
+#        This is why there is mixed and hardcoded OVS versions at the moment 
+RUN cd ~ && \
+    wget https://www.openvswitch.org/releases/openvswitch-2.11.1.tar.gz && \
+    tar xf openvswitch-2.11.1.tar.gz && \
+    rm -f openvswitch-2.11.1.tar.gz && \
+    cd openvswitch-2.11.1 && \
+    sed -e 's/@VERSION@/0.0.1/' rhel/openvswitch-fedora.spec.in > /tmp/ovs.spec && \
+    yum-builddep -y /tmp/ovs.spec && \
+    ./boot.sh && \
+    ./configure --prefix=/usr/ --with-dpdk=$DPDK_BUILD && \
+    make rpm-fedora RPMBUILD_OPT="--with dpdk --without check" && \
+    make install
+
+RUN rpm -ivh ~/openvswitch-2.11.1/rpm/rpmbuild/RPMS/x86_64/openvswitch-2.11.1-1.el7.x86_64.rpm && \
+    rpm -ivh ~/openvswitch-2.11.1/rpm/rpmbuild/RPMS/x86_64/openvswitch-devel-2.11.1-1.el7.x86_64.rpm && \
+    rpm -ivh https://github.com/alauda/ovs/releases/download/${OVS_VERSION}-${OVS_SUBVERSION}/ovn-${OVS_VERSION}-${OVS_SUBVERSION}.el7.x86_64.rpm && \
+    rpm -ivh https://github.com/alauda/ovs/releases/download/${OVS_VERSION}-${OVS_SUBVERSION}/ovn-common-${OVS_VERSION}-${OVS_SUBVERSION}.el7.x86_64.rpm && \
+    rpm -ivh https://github.com/alauda/ovs/releases/download/${OVS_VERSION}-${OVS_SUBVERSION}/ovn-vtep-${OVS_VERSION}-${OVS_SUBVERSION}.el7.x86_64.rpm && \
+    rpm -ivh https://github.com/alauda/ovs/releases/download/${OVS_VERSION}-${OVS_SUBVERSION}/ovn-central-${OVS_VERSION}-${OVS_SUBVERSION}.el7.x86_64.rpm && \
+    rpm -ivh https://github.com/alauda/ovs/releases/download/${OVS_VERSION}-${OVS_SUBVERSION}/ovn-host-${OVS_VERSION}-${OVS_SUBVERSION}.el7.x86_64.rpm
+
+RUN mkdir -p /var/run/openvswitch && \
+    mkdir -p /etc/cni/net.d && \
+    mkdir -p /opt/cni/bin
+
+COPY ovs-dpdk-healthcheck.sh /root/ovs-dpdk-healthcheck.sh
+COPY start-ovs-dpdk.sh /root/start-ovs-dpdk.sh
+
+CMD ["/bin/bash", "/root/start-ovs-dpdk.sh"]

--- a/dist/images/ovs-dpdk-healthcheck.sh
+++ b/dist/images/ovs-dpdk-healthcheck.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Will need a proper healthcheck for ovs-dpdk,
+# this was just a dummy to allow me test withoiut errors
+# ovs-vsctl get Open_vSwitch . dpdk_initialized
+
+set -euo pipefail
+
+echo foo

--- a/dist/images/start-ovs-dpdk.sh
+++ b/dist/images/start-ovs-dpdk.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+function quit {
+	/usr/share/openvswitch/scripts/ovs-ctl stop
+	/usr/share/openvswitch/scripts/ovn-ctl stop_controller
+	/usr/share/openvswitch/scripts/ovn-ctl stop_controller_vtep
+	exit 0
+}
+trap quit EXIT
+
+# Start ovsdb
+/usr/share/openvswitch/scripts/ovs-ctl restart --no-ovsdb-server  --system-id=random
+/usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
+
+/usr/share/openvswitch/scripts/ovs-ctl --no-ovs-vswitchd start
+/usr/share/openvswitch/scripts/ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-socket-mem="1024,0"
+/usr/share/openvswitch/scripts/ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-init=true
+/usr/share/openvswitch/scripts/ovs-vsctl --no-wait set Open_vSwitch . other_config:pmd-cpu-mask=0x3
+/usr/share/openvswitch/scripts/ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-lcore-mask=0xc
+
+# Start ovn-controller
+/usr/share/openvswitch/scripts/ovn-ctl restart_controller
+/usr/share/openvswitch/scripts/ovn-ctl restart_controller_vtep
+
+# Set remote ovn-sb for ovn-controller to connect to
+ovs-vsctl set open . external-ids:ovn-remote=tcp:"${OVN_SB_SERVICE_HOST}":"${OVN_SB_SERVICE_PORT}"
+ovs-vsctl set open . external-ids:ovn-remote-probe-interval=10000
+ovs-vsctl set open . external-ids:ovn-encap-type=geneve
+
+tail -f /var/log/openvswitch/ovs-vswitchd.log

--- a/yamls/ovn-dpdk.yaml
+++ b/yamls/ovn-dpdk.yaml
@@ -1,0 +1,317 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-ovn
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ovn-config
+  namespace: kube-ovn
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovn
+  namespace: kube-ovn
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.k8s.io/system-only: "true"
+  name: system:ovn
+rules:
+  - apiGroups:
+      - "kubeovn.io"
+    resources:
+      - subnets
+      - subnets/status
+      - ips
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - namespaces
+      - nodes
+      - configmaps
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - ""
+      - networking.k8s.io
+      - apps
+    resources:
+      - networkpolicies
+      - services
+      - endpoints
+      - statefulsets
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovn
+roleRef:
+  name: system:ovn
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: ovn
+    namespace: kube-ovn
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ovn-nb
+  namespace: kube-ovn
+spec:
+  ports:
+    - name: ovn-nb
+      protocol: TCP
+      port: 6641
+      targetPort: 6641
+  type: ClusterIP
+  selector:
+    app: ovn-central
+  sessionAffinity: None
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ovn-sb
+  namespace: kube-ovn
+spec:
+  ports:
+    - name: ovn-sb
+      protocol: TCP
+      port: 6642
+      targetPort: 6642
+  type: ClusterIP
+  selector:
+    app: ovn-central
+  sessionAffinity: None
+
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ovn-central
+  namespace: kube-ovn
+  annotations:
+    kubernetes.io/description: |
+      OVN components: northd, nb and sb.
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 0%
+      maxUnavailable: 100%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ovn-central
+  template:
+    metadata:
+      labels:
+        app: ovn-central
+        component: network
+        type: infra
+    spec:
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: ovn-central
+              topologyKey: kubernetes.io/hostname
+      serviceAccountName: ovn
+      hostNetwork: true
+      containers:
+        - name: ovn-central
+          image: "index.alauda.cn/alaudak8s/kube-ovn-db:v0.8.0"
+          imagePullPolicy: Never
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          resources:
+            requests:
+              cpu: 200m
+              memory: 300Mi
+            limits:
+              cpu: 400m
+              memory: 800Mi
+          volumeMounts:
+            - mountPath: /run/openvswitch
+              name: host-run-ovs
+            - mountPath: /var/run/openvswitch
+              name: host-run-ovs
+            - mountPath: /sys
+              name: host-sys
+              readOnly: true
+            - mountPath: /etc/openvswitch
+              name: host-config-openvswitch
+            - mountPath: /var/log/openvswitch
+              name: host-log
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - /root/ovn-is-leader.sh
+            periodSeconds: 3
+          livenessProbe:
+            exec:
+              command:
+              - sh
+              - /root/ovn-healthcheck.sh
+            initialDelaySeconds: 30
+            periodSeconds: 7
+            failureThreshold: 5
+      nodeSelector:
+        beta.kubernetes.io/os: "linux"
+        kube-ovn/role: "master"
+      volumes:
+        - name: host-run-ovs
+          hostPath:
+            path: /run/openvswitch
+        - name: host-sys
+          hostPath:
+            path: /sys
+        - name: host-config-openvswitch
+          hostPath:
+            path: /etc/origin/openvswitch
+        - name: host-log
+          hostPath:
+            path: /var/log/openvswitch
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovs-ovn
+  namespace: kube-ovn
+  annotations:
+    kubernetes.io/description: |
+      This daemon set launches the openvswitch daemon.
+spec:
+  selector:
+    matchLabels:
+      app: ovs
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovs
+        component: network
+        type: infra
+    spec:
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      serviceAccountName: ovn
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: openvswitch-dpdk-test
+          image: "ovs-dpdk-test"
+          imagePullPolicy: Never
+          securityContext:
+            runAsUser: 0
+            privileged: true
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: host-modules
+              readOnly: true
+            - mountPath: /run/openvswitch
+              name: host-run-ovs
+            - mountPath: /var/run/openvswitch
+              name: host-run-ovs
+            - mountPath: /sys
+              name: host-sys
+              readOnly: true
+            - mountPath: /etc/openvswitch
+              name: host-config-openvswitch
+            - mountPath: /var/log/openvswitch
+              name: host-log
+            - mountPath: /dev/hugepages
+              name: hugepage
+          readinessProbe:
+            exec:
+              command:
+              - sh
+              - /root/ovs-dpdk-healthcheck.sh
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+              - sh
+              - /root/ovs-dpdk-healthcheck.sh
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 1Gi
+            limits:
+              cpu: 200m
+              memory: 1Gi
+              hugepages-1Gi: 1Gi
+      nodeSelector:
+        beta.kubernetes.io/os: "linux"
+      volumes:
+        - name: host-modules
+          hostPath:
+            path: /lib/modules
+        - name: host-run-ovs
+          hostPath:
+            path: /run/openvswitch
+        - name: host-sys
+          hostPath:
+            path: /sys
+        - name: host-config-openvswitch
+          hostPath:
+            path: /etc/origin/openvswitch
+        - name: host-log
+          hostPath:
+            path: /var/log/openvswitch
+        - name: hugepage
+          emptyDir:
+            medium: HugePages
+


### PR DESCRIPTION
Not intended to merge. Just sharing some files for discussion
in issue 104: https://github.com/alauda/kube-ovn/issues/104

Based on kube-ovn v0.8.0, I've not attempted to upgrade to 0.9,
but may work..

Set the KERNEL_MOD variable on line 40 of  dist/images/Dockerfile.dpdk
Build the ovs-dpdk Docker image. I tagged it "ovs-dpdk-test"
docker build -t ovs-dpdk-test -f Dockerfile.dpdk .

Follow the process at docs/install.md.  I used v0.8.0.
Do not do step 3 to install OVS and OVN. Instead do the following:
kubectl apply -f yamls/ovn-dpdk.yaml

Continue with install process from step 4. I used v0.8.0.
OVS-DPDK should now function juts like the kernel OVS.
You have the added option to create port types of dpdkvhostuser
ovs-vsctl add-port <bridge> <sock> -- set Interface <sock>
type=dpdkvhostuser
Socket file should appear under /var/run/openvswitch/ or similar,
depends on ovs config

SIDE NOTE: To run with Multus I created a basic CRD:
cat <<EOF | kubectl create -f -
apiVersion: "k8s.cni.cncf.io/v1"
kind: NetworkAttachmentDefinition
metadata:
  name: kube-ovn
spec:
  config: '{
      "cniVersion": "0.3.0",
      "type": "kube-ovn",
	  "server_socket":"/run/openvswitch/kube-ovn-daemon.sock"
    }'
EOF

If you install Multus now kube-ovn should become the default
network. At this point you should be able to connect multiple
kube-ovn ports. The pod spec should look something like the
snip below. However, the veth names clash so the second port
fails. Should be an easy fix to change the kube-ovn script to
create unique veths.
However you can now request additional ports from another
CNI plugin.

metadata:
  annotations:
    k8s.v1.cni.cncf.io/networks: kube-ovn