### PR TITLE
fix: if cidr block not ends with zero, reformat it

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -262,6 +262,14 @@ func (c *Controller) processNextDeleteSubnetWorkItem() bool {
 func formatSubnet(subnet *kubeovnv1.Subnet, c *Controller) error {
 	var err error
 	changed := false
+	_, ipNet, err := net.ParseCIDR(subnet.Spec.CIDRBlock)
+	if err != nil {
+		return fmt.Errorf("subnet %s cidr %s is not a valid cidrblock", subnet.Name, subnet.Spec.CIDRBlock )
+	}
+	if ipNet.String() != subnet.Spec.CIDRBlock {
+		subnet.Spec.CIDRBlock = ipNet.String()
+		changed = true
+	}
 	if subnet.Spec.Protocol == "" || subnet.Spec.Protocol != util.CheckProtocol(subnet.Spec.CIDRBlock) {
 		subnet.Spec.Protocol = util.CheckProtocol(subnet.Spec.CIDRBlock)
 		changed = true

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -163,7 +163,12 @@ func (c *Controller) reconcileRouters() error {
 	}
 	cidrs := []string{}
 	for _, subnet := range subnets {
-		cidrs = append(cidrs, subnet.Spec.CIDRBlock)
+		_, ipNet, err := net.ParseCIDR(subnet.Spec.CIDRBlock)
+		if err != nil {
+			klog.Errorf("%s is not a valid cidr block", subnet.Spec.CIDRBlock)
+		} else {
+			cidrs = append(cidrs, ipNet.String())
+		}
 	}
 	node, err := c.config.KubeClient.CoreV1().Nodes().Get(c.config.NodeName, metav1.GetOptions{})
 	if err != nil {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -86,6 +86,7 @@ func (f *Framework) WaitPodReady(pod, namespace string) error {
 		case Initing, Pending, PodInitializing, ContainerCreating, Terminating:
 			continue
 		default:
+			fmt.Printf("%v", p.String())
 			return fmt.Errorf("pod status failed")
 		}
 	}

--- a/test/e2e/ip/static_ip.go
+++ b/test/e2e/ip/static_ip.go
@@ -39,7 +39,7 @@ var _ = Describe("[IP Allocation]", func() {
 					Containers: []corev1.Container{
 						{
 							Name:  name,
-							Image: "nginx:alpine",
+							Image: "index.alauda.cn/library/nginx:alpine",
 						},
 					},
 					AutomountServiceAccountToken: &autoMount,

--- a/test/e2e/subnet/normal.go
+++ b/test/e2e/subnet/normal.go
@@ -148,4 +148,30 @@ var _ = Describe("[Subnet]", func() {
 
 		})
 	})
+
+	Describe("cidr with nonstandard style", func() {
+		It("cidr ends with nonzero", func() {
+			name := f.GetName()
+			By("create subnet")
+			s := &kubeovn.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+					Labels: map[string]string{"e2e": "true"},
+				},
+				Spec: kubeovn.SubnetSpec{
+					CIDRBlock: "11.14.0.1/16",
+				},
+			}
+
+			_, err := f.OvnClientSet.KubeovnV1().Subnets().Create(s)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = f.WaitSubnetReady(name)
+			Expect(err).NotTo(HaveOccurred())
+
+			s, err = f.OvnClientSet.KubeovnV1().Subnets().Get(name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(s.Spec.CIDRBlock).To(Equal("11.14.0.0/16"))
+		})
+	})
 })


### PR DESCRIPTION
ip route can not add route to cidr like 10.16.16.1/24, only 10.16.16.0/24 that ends with zero can be accepted