### PR TITLE
fix: do not return not found err

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -293,7 +293,7 @@ func (c *Controller) handleAddNode(key string) error {
 		}
 	}
 
-	return err
+	return nil
 }
 
 func (c *Controller) handleDeleteNode(key string) error {


### PR DESCRIPTION
when first add node, the related ip cr doesn't exist and will pop the error log:
`E1230 06:24:57.593798       1 node.go:118] error syncing 'kube-ovn-control-plane': ips.kubeovn.io "node-kube-ovn-control-plane" not found, requeuing`