### PR TITLE
fix: restart nbctl-daemon if not response

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -43,5 +43,12 @@ func loopOvnNbctlDaemon(config *controller.Configuration) {
 		if _, err := os.Stat(daemonSocket); os.IsNotExist(err) || daemonSocket == "" {
 			ovs.StartOvnNbctlDaemon(config.OvnNbHost, config.OvnNbPort)
 		}
+
+		// ovn-nbctl daemon may hang and cannot precess further request.
+		// In case of that, we need to start a new daemon.
+		if  err := ovs.CheckAlive(); err != nil {
+			klog.Warningf("ovn-nbctl daemon doesn't return, start a new daemon")
+			ovs.StartOvnNbctlDaemon(config.OvnNbHost, config.OvnNbPort)
+		}
 	}
 }

--- a/cmd/webhook/server.go
+++ b/cmd/webhook/server.go
@@ -100,5 +100,10 @@ func loopOvnNbctlDaemon(ovnNbHost string, ovnNbPort int) {
 		if _, err := os.Stat(daemonSocket); os.IsNotExist(err) || daemonSocket == "" {
 			ovs.StartOvnNbctlDaemon(ovnNbHost, ovnNbPort)
 		}
+
+		if  err := ovs.CheckAlive(); err != nil {
+			klog.Warningf("ovn-nbctl daemon doesn't return, start a new daemon")
+			ovs.StartOvnNbctlDaemon(ovnNbHost, ovnNbPort)
+		}
 	}
 }

--- a/dist/images/Dockerfile.controller
+++ b/dist/images/Dockerfile.controller
@@ -29,4 +29,5 @@ WORKDIR /kube-ovn
 CMD ["sh", "start-controller.sh"]
 
 COPY start-controller.sh /kube-ovn/start-controller.sh
+COPY kube-ovn-controller-healthcheck.sh /kube-ovn/kube-ovn-controller-healthcheck.sh
 COPY kube-ovn-controller /kube-ovn/kube-ovn-controller

--- a/dist/images/kube-ovn-controller-healthcheck.sh
+++ b/dist/images/kube-ovn-controller-healthcheck.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+OVN_NB_DAEMON=/var/run/openvswitch/ovn-nbctl.$(cat /var/run/openvswitch/ovn-nbctl.pid).ctl ovn-nbctl --timeout=10 show > /dev/null
+
+nc -z -w3 127.0.0.1 10660
+
+nc -z -w3 "$KUBERNETES_SERVICE_HOST" "$KUBERNETES_SERVICE_PORT"

--- a/dist/images/start-controller.sh
+++ b/dist/images/start-controller.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-export OVN_NB_DAEMON=$(ovn-nbctl --db=tcp:["${OVN_NB_SERVICE_HOST}"]:"${OVN_NB_SERVICE_PORT}" --pidfile --detach)
+export OVN_NB_DAEMON=$(ovn-nbctl --db=tcp:["${OVN_NB_SERVICE_HOST}"]:"${OVN_NB_SERVICE_PORT}" --pidfile --detach --overwrite-pidfile)
 exec ./kube-ovn-controller --ovn-nb-host="${OVN_NB_SERVICE_HOST}" --ovn-nb-port="${OVN_NB_SERVICE_PORT}" $@

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -63,20 +63,14 @@ spec:
           readinessProbe:
             exec:
               command:
-                - nc
-                - -z
-                - -w3
-                - 127.0.0.1
-                - "10660"
+                - sh
+                - /kube-ovn/kube-ovn-controller-healthcheck.sh
             periodSeconds: 3
           livenessProbe:
             exec:
               command:
-                - nc
-                - -z
-                - -w3
-                - 127.0.0.1
-                - "10660"
+                - sh
+                - /kube-ovn/kube-ovn-controller-healthcheck.sh
             initialDelaySeconds: 30
             periodSeconds: 7
             failureThreshold: 5


### PR DESCRIPTION
Sometimes nbctl-daemon may hang and not response anymore and all request to ovn-nb will failed. We need to check nbctl-daemon repeatedly and use liveness prob to kill the controller that can not connect to ovn-nb for a period.