### PR TITLE
fix: alleviate ping lost

### DIFF
--- a/pkg/pinger/ping.go
+++ b/pkg/pinger/ping.go
@@ -53,9 +53,9 @@ func pingNodes(config *Configuration) {
 						return
 					}
 					pinger.SetPrivileged(true)
-					pinger.Timeout = 1 * time.Second
+					pinger.Timeout = 30 * time.Second
 					pinger.Count = 3
-					pinger.Interval = 1 * time.Millisecond
+					pinger.Interval = 100 * time.Millisecond
 					pinger.Debug = true
 					pinger.Run()
 					stats := pinger.Statistics()


### PR DESCRIPTION
We still don't know the root cause of why ping will lost packet. It seems that lager timeout and interval can alleviate the symptom.

related to #122 