### PR TITLE
fix: wait for container network ready before cni return

### DIFF
--- a/pkg/daemon/gateway.go
+++ b/pkg/daemon/gateway.go
@@ -52,7 +52,6 @@ var (
 )
 
 func (c *Controller) runGateway() {
-	klog.Info("reconcile gateway")
 	subnets, err := c.getSubnetsCIDR(c.protocol)
 	if err != nil {
 		klog.Errorf("get subnets failed, %+v", err)


### PR DESCRIPTION
When cluster with thousands pods, it take time for ovs network take effect. To avoid pods run before network ready, wait network ready in cniserver