### PR TITLE
fix: disable ovn-nb inactivity_probe

### DIFF
--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -44,6 +44,7 @@ trap quit EXIT
 if [[ -z "$NODE_IPS" ]]; then
     /usr/share/openvswitch/scripts/ovn-ctl restart_northd
     ovn-nbctl set-connection ptcp:"${DB_NB_PORT}":["${DB_NB_ADDR}"]
+    ovn-nbctl set Connection . inactivity_probe=0
     ovn-sbctl set-connection ptcp:"${DB_SB_PORT}":["${DB_SB_ADDR}"]
     ovn-sbctl set Connection . inactivity_probe=0
 else

--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -74,7 +74,7 @@ spec:
                 - -w3
                 - 127.0.0.1
                 - "10660"
-            initialDelaySeconds: 30
+            initialDelaySeconds: 300
             periodSeconds: 7
             failureThreshold: 5
       nodeSelector:

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -71,7 +71,7 @@ spec:
               command:
                 - sh
                 - /kube-ovn/kube-ovn-controller-healthcheck.sh
-            initialDelaySeconds: 30
+            initialDelaySeconds: 300
             periodSeconds: 7
             failureThreshold: 5
       nodeSelector:


### PR DESCRIPTION
The ovn-nbctl daemon in kube-ovn-controller need to keep a long connection, the default inactivity_probe will drop the connection.