### PR TITLE
webhook: remove leader-election configs

### DIFF
--- a/cmd/webhook/server.go
+++ b/cmd/webhook/server.go
@@ -57,9 +57,6 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,
-		LeaderElection:          true,
-		LeaderElectionNamespace: os.Getenv("KUBE_NAMESPACE"),
-		LeaderElectionID:        os.Getenv("POD_NAME"),
 		// disable metrics to avoid port conflict
 		MetricsBindAddress: "0",
 	})

--- a/yamls/webhook.yaml
+++ b/yamls/webhook.yaml
@@ -49,15 +49,6 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: KUBE_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
           readinessProbe:
             tcpSocket:
               port: 8443


### PR DESCRIPTION
Webhooks are several web servers which is serving independently, leader election is not needed in this scenario.