### PR TITLE
fix:enable bash alias option in Dockerfile CMD scripts

### DIFF
--- a/dist/images/ovn-healthcheck.sh
+++ b/dist/images/ovn-healthcheck.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+shopt -s expand_aliases
 
 alias ovn-ctl='/usr/share/ovn/scripts/ovn-ctl'
 

--- a/dist/images/ovn-is-leader.sh
+++ b/dist/images/ovn-is-leader.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+shopt -s expand_aliases
 
 alias ovn-ctl='/usr/share/ovn/scripts/ovn-ctl'
 

--- a/dist/images/ovs-healthcheck.sh
+++ b/dist/images/ovs-healthcheck.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+shopt -s expand_aliases
 
 alias ovs-ctl='/usr/share/openvswitch/scripts/ovs-ctl'
 alias ovn-ctl='/usr/share/ovn/scripts/ovn-ctl'


### PR DESCRIPTION
set `shopt -s expand_aliases` in bash scripts to make alias command available when using `./ovn-healthcheck.sh`