### PR TITLE
refactor ipam

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ REGISTRY=index.alauda.cn/alaudak8s
 DEV_TAG=dev
 RELEASE_TAG=$(shell cat VERSION)
 
-.PHONY: build-dev-images build-go build-bin lint up down halt suspend resume kind push-dev push-release
+.PHONY: build-dev-images build-go build-bin lint up down halt suspend resume kind-init kind-init-ha kind-reload push-dev push-release e2e ut
 
 build-dev-images: build-bin
 	docker build -t ${REGISTRY}/kube-ovn:${DEV_TAG} -f dist/images/Dockerfile dist/images/
@@ -74,11 +74,14 @@ kind-init-ha:
 	kubectl apply -f yamls/kube-ovn.yaml
 
 kind-reload:
-    kind load docker-image --name kube-ovn ${REGISTRY}/kube-ovn:${RELEASE_TAG}
-	kubectl delete pod -n kube-ovn --all
+	kind load docker-image --name kube-ovn ${REGISTRY}/kube-ovn:${RELEASE_TAG}
+	kubectl delete pod -n kube-system -l app=kube-ovn-controller
 
 kind-clean:
 	kind delete cluster --name=kube-ovn
 
 e2e:
 	ginkgo -p --slowSpecThreshold=60 test/e2e
+
+ut:
+	ginkgo -p --slowSpecThreshold=60 test/unittest

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -192,28 +192,33 @@ func (c *Controller) handleAddNode(key string) error {
 		return err
 	}
 
-	nic, err := c.ovnClient.CreatePort(
-		c.config.NodeSwitch, fmt.Sprintf("node-%s", key),
-		node.Annotations[util.IpAddressAnnotation],
-		node.Annotations[util.CidrAnnotation],
-		node.Annotations[util.MacAddressAnnotation])
-	if err != nil {
-		return err
-	}
-
-	nodeAddr := getNodeInternalIP(node)
-	if util.CheckProtocol(nodeAddr) == util.CheckProtocol(nic.IpAddress) {
-		err = c.ovnClient.AddStaticRoute("", nodeAddr, strings.Split(nic.IpAddress, "/")[0], c.config.ClusterRouter)
-		if err != nil {
-			klog.Errorf("failed to add static router from node to ovn0 %v", err)
-			return err
-		}
-	}
-
 	subnet, err := c.subnetsLister.Get(c.config.NodeSwitch)
 	if err != nil {
 		klog.Errorf("failed to get node subnet %v", err)
 		return err
+	}
+
+	var ip, mac string
+	portName := fmt.Sprintf("node-%s", key)
+	if node.Annotations[util.AllocatedAnnotation] == "true" {
+		return nil
+	} else {
+		ip, mac, err = c.ipam.GetRandomAddress(portName, c.config.NodeSwitch)
+		if err != nil {
+			return err
+		}
+	}
+	if err := c.ovnClient.CreatePort(c.config.NodeSwitch, portName, ip, subnet.Spec.CIDRBlock, mac); err != nil {
+		return err
+	}
+
+	nodeAddr := getNodeInternalIP(node)
+	if util.CheckProtocol(nodeAddr) == util.CheckProtocol(ip) {
+		err = c.ovnClient.AddStaticRoute("", nodeAddr, strings.Split(ip, "/")[0], c.config.ClusterRouter)
+		if err != nil {
+			klog.Errorf("failed to add static router from node to ovn0 %v", err)
+			return err
+		}
 	}
 
 	patchPayloadTemplate :=
@@ -223,11 +228,12 @@ func (c *Controller) handleAddNode(key string) error {
         "value": %s
     }]`
 	payload := map[string]string{
-		util.IpAddressAnnotation:     nic.IpAddress,
-		util.MacAddressAnnotation:    nic.MacAddress,
+		util.IpAddressAnnotation:     ip,
+		util.MacAddressAnnotation:    mac,
 		util.CidrAnnotation:          subnet.Spec.CIDRBlock,
 		util.GatewayAnnotation:       subnet.Spec.Gateway,
 		util.LogicalSwitchAnnotation: c.config.NodeSwitch,
+		util.AllocatedAnnotation:     "true",
 		util.PortNameAnnotation:      fmt.Sprintf("node-%s", key),
 	}
 	raw, _ := json.Marshal(payload)
@@ -256,17 +262,17 @@ func (c *Controller) handleAddNode(key string) error {
 					PodName:    key,
 					Subnet:     c.config.NodeSwitch,
 					NodeName:   key,
-					IPAddress:  nic.IpAddress,
-					MacAddress: nic.MacAddress,
+					IPAddress:  ip,
+					MacAddress: mac,
 				},
 			})
 			if err != nil {
-				errMsg := fmt.Errorf("failed to create ip crd for %s, %v", nic.IpAddress, err)
+				errMsg := fmt.Errorf("failed to create ip crd for %s, %v", ip, err)
 				klog.Error(errMsg)
 				return errMsg
 			}
 		} else {
-			errMsg := fmt.Errorf("failed to get ip crd for %s, %v", nic.IpAddress, err)
+			errMsg := fmt.Errorf("failed to get ip crd for %s, %v", ip, err)
 			klog.Error(errMsg)
 			return errMsg
 		}
@@ -282,12 +288,12 @@ func (c *Controller) handleAddNode(key string) error {
 		ipCr.Spec.Namespace = ""
 		ipCr.Spec.Subnet = c.config.NodeSwitch
 		ipCr.Spec.NodeName = key
-		ipCr.Spec.IPAddress = nic.IpAddress
-		ipCr.Spec.MacAddress = nic.MacAddress
+		ipCr.Spec.IPAddress = ip
+		ipCr.Spec.MacAddress = mac
 		ipCr.Spec.ContainerID = ""
 		_, err := c.config.KubeOvnClient.KubeovnV1().IPs().Update(ipCr)
 		if err != nil {
-			errMsg := fmt.Errorf("failed to create ip crd for %s, %v", nic.IpAddress, err)
+			errMsg := fmt.Errorf("failed to create ip crd for %s, %v", ip, err)
 			klog.Error(errMsg)
 			return errMsg
 		}
@@ -298,31 +304,23 @@ func (c *Controller) handleAddNode(key string) error {
 
 func (c *Controller) handleDeleteNode(key string) error {
 	portName := fmt.Sprintf("node-%s", key)
-	err := c.ovnClient.DeletePort(portName)
-	if err != nil {
+	if err := c.ovnClient.DeletePort(portName); err != nil {
 		klog.Errorf("failed to delete node switch port node-%s %v", key, err)
 		return err
 	}
 
-	ipCr, err := c.config.KubeOvnClient.KubeovnV1().IPs().Get(portName, metav1.GetOptions{})
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
+	if err := c.config.KubeOvnClient.KubeovnV1().IPs().Delete(portName, &metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
 		return err
 	}
 
-	if err := c.ovnClient.DeleteStaticRouteByNextHop(ipCr.Spec.IPAddress); err != nil {
-		return err
+	ip, _, exist := c.ipam.GetPodAddress(portName)
+	if exist {
+		if err := c.ovnClient.DeleteStaticRouteByNextHop(ip); err != nil {
+			return err
+		}
 	}
 
-	err = c.config.KubeOvnClient.KubeovnV1().IPs().Delete(portName, &metav1.DeleteOptions{})
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
+	c.ipam.ReleaseAddressByPod(portName)
 	return nil
 }
 

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -350,6 +350,10 @@ func (c *Controller) handleAddSubnet(key string) error {
 		return err
 	}
 
+	if err := c.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.ExcludeIps); err != nil {
+		return err
+	}
+
 	exist, err := c.ovnClient.LogicalSwitchExists(subnet.Name)
 	if err != nil {
 		klog.Errorf("failed to list logical switch, %v", err)
@@ -590,6 +594,10 @@ func (c *Controller) handleUpdateSubnet(key string) error {
 		return nil
 	}
 
+	if err := c.ipam.AddOrUpdateSubnet(subnet.Name, subnet.Spec.CIDRBlock, subnet.Spec.ExcludeIps); err != nil {
+		return err
+	}
+
 	exist, err := c.ovnClient.LogicalSwitchExists(subnet.Name)
 	if err != nil {
 		klog.Errorf("failed to list logical switch, %v", err)
@@ -726,6 +734,8 @@ func (c *Controller) handleDeleteRoute(key string) error {
 }
 
 func (c *Controller) handleDeleteSubnet(key string) error {
+	c.ipam.DeleteSubnet(key)
+
 	exist, err := c.ovnClient.LogicalSwitchExists(key)
 	if err != nil {
 		klog.Errorf("failed to list logical switch, %v", err)

--- a/pkg/ipam/ip.go
+++ b/pkg/ipam/ip.go
@@ -1,0 +1,168 @@
+package ipam
+
+import (
+	"github.com/alauda/kube-ovn/pkg/util"
+	"math/big"
+	"strings"
+)
+
+type IP string
+
+type IPRange struct {
+	Start IP
+	End   IP
+}
+
+func (a IP) Equal(b IP) bool {
+	return a == b
+}
+
+func (a IP) LessThan(b IP) bool {
+	return util.Ip2BigInt(string(a)).Cmp(util.Ip2BigInt(string(b))) == -1
+}
+
+func (a IP) GreaterThan(b IP) bool {
+	return util.Ip2BigInt(string(a)).Cmp(util.Ip2BigInt(string(b))) == 1
+}
+
+func (a IP) Add(num int64) IP {
+	return IP(util.BigInt2Ip(big.NewInt(0).Add(util.Ip2BigInt(string(a)), big.NewInt(num))))
+}
+
+func (ipr IPRange) IPExist(ip IP) bool {
+	return (ipr.Start.LessThan(ip) || ipr.Start.Equal(ip)) &&
+		(ipr.End.GreaterThan(ip) || ipr.End.Equal(ip))
+}
+
+type IPRangeList []*IPRange
+
+func (iprl IPRangeList) Contains(ip IP) bool {
+	for _, ipr := range iprl {
+		if ipr.IPExist(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func splitIPRangeList(iprl IPRangeList, ip IP) (bool, IPRangeList) {
+	newIPRangeList := []*IPRange{}
+	split := false
+	for _, ipr := range iprl {
+		if split {
+			newIPRangeList = append(newIPRangeList, ipr)
+			continue
+		}
+
+		if ipr.Start.Equal(ipr.End) && ipr.Start.Equal(ip) {
+			split = true
+			continue
+		}
+
+		if ipr.Start.Equal(ip) {
+			newIPRangeList = append(newIPRangeList, &IPRange{Start: ip.Add(1), End: ipr.End})
+			split = true
+			continue
+		}
+
+		if ipr.End.Equal(ip) {
+			newIPRangeList = append(newIPRangeList, &IPRange{Start: ipr.Start, End: ip.Add(-1)})
+			split = true
+			continue
+		}
+
+		if ipr.IPExist(ip) {
+			newIpr1 := IPRange{Start: ipr.Start, End: ip.Add(-1)}
+			newIpr2 := IPRange{Start: ip.Add(1), End: ipr.End}
+			newIPRangeList = append(newIPRangeList, &newIpr1, &newIpr2)
+			split = true
+			continue
+		}
+
+		newIPRangeList = append(newIPRangeList, ipr)
+	}
+	return split, newIPRangeList
+}
+
+func mergeIPRangeList(iprl IPRangeList, ip IP) (bool, IPRangeList) {
+	insertIPRangeList := []*IPRange{}
+	inserted := false
+	if iprl.Contains(ip) {
+		return false, nil
+	}
+
+	for _, ipr := range iprl {
+		if inserted || ipr.Start.LessThan(ip) {
+			insertIPRangeList = append(insertIPRangeList, ipr)
+			continue
+		}
+
+		if ipr.Start.GreaterThan(ip) {
+			insertIPRangeList = append(insertIPRangeList, &IPRange{Start: ip, End: ip}, ipr)
+			inserted = true
+			continue
+		}
+	}
+	if !inserted {
+		newIpr := IPRange{Start: ip, End: ip}
+		insertIPRangeList = append(insertIPRangeList, &newIpr)
+	}
+
+	mergedIPRangeList := []*IPRange{}
+	for _, ipr := range insertIPRangeList {
+		if len(mergedIPRangeList) == 0 {
+			mergedIPRangeList = append(mergedIPRangeList, ipr)
+			continue
+		}
+
+		if mergedIPRangeList[len(mergedIPRangeList)-1].End.Add(1).Equal(ipr.Start) {
+			mergedIPRangeList[len(mergedIPRangeList)-1].End = ipr.End
+		} else {
+			mergedIPRangeList = append(mergedIPRangeList, ipr)
+		}
+	}
+
+	return true, mergedIPRangeList
+}
+
+func convertExcludeIps(excludeIps []string) IPRangeList {
+	newIPRangeList := make([]*IPRange, 0, len(excludeIps))
+	for _, ex := range excludeIps {
+		ips := strings.Split(ex, "..")
+		if len(ips) == 1 {
+			ipr := IPRange{Start: IP(ips[0]), End: IP(ips[0])}
+			newIPRangeList = append(newIPRangeList, &ipr)
+		} else {
+			ipr := IPRange{Start: IP(ips[0]), End: IP(ips[1])}
+			newIPRangeList = append(newIPRangeList, &ipr)
+		}
+	}
+	return newIPRangeList
+}
+
+func splitRange(a, b *IPRange) IPRangeList {
+	if b.End.LessThan(a.Start) || b.Start.GreaterThan(a.End) {
+		return IPRangeList{a}
+	}
+
+	if (a.Start.Equal(b.Start) || a.Start.GreaterThan(b.Start)) &&
+		(a.End.Equal(b.End) || a.End.LessThan(b.End)) {
+		return nil
+	}
+
+	if (a.Start.Equal(b.Start) || a.Start.GreaterThan(b.Start)) &&
+		a.End.GreaterThan(b.End) {
+		ipr := IPRange{Start: b.End.Add(1), End: a.End}
+		return IPRangeList{&ipr}
+	}
+
+	if (a.End.Equal(b.End) || a.End.LessThan(b.End)) &&
+		a.Start.LessThan(b.Start) {
+		ipr := IPRange{Start: a.Start, End: b.Start.Add(-1)}
+		return IPRangeList{&ipr}
+	}
+
+	ipr1 := IPRange{Start: a.Start, End: b.Start.Add(-1)}
+	ipr2 := IPRange{Start: b.End.Add(1), End: a.End}
+	return IPRangeList{&ipr1, &ipr2}
+}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -1,0 +1,111 @@
+package ipam
+
+import (
+	"errors"
+	"github.com/alauda/kube-ovn/pkg/util"
+	"k8s.io/klog"
+	"net"
+	"sync"
+)
+
+var (
+	OutOfRangeError  = errors.New("AddressOutOfRange")
+	ConflictError    = errors.New("AddressConflict")
+	NoAvailableError = errors.New("NoAvailableAddress")
+	InvalidCIDRError = errors.New("CIDRInvalid")
+)
+
+type IPAM struct {
+	mutex   sync.RWMutex
+	Subnets map[string]*Subnet
+}
+
+func NewIPAM() *IPAM {
+	return &IPAM{
+		mutex:   sync.RWMutex{},
+		Subnets: map[string]*Subnet{},
+	}
+}
+
+func (ipam *IPAM) GetRandomAddress(podName string, subnetName string) (string, string, error) {
+	ipam.mutex.RLock()
+	defer ipam.mutex.RUnlock()
+	if subnet, ok := ipam.Subnets[subnetName]; !ok {
+		return "", "", NoAvailableError
+	} else {
+		ip, mac, err := subnet.GetRandomAddress(podName)
+		klog.Infof("allocate %s %s for %s", ip, mac, podName)
+		return string(ip), mac, err
+	}
+}
+
+func (ipam *IPAM) GetStaticAddress(podName string, ip, mac string, subnetName string) (string, string, error) {
+	ipam.mutex.RLock()
+	defer ipam.mutex.RUnlock()
+	if subnet, ok := ipam.Subnets[subnetName]; !ok {
+		return "", "", NoAvailableError
+	} else {
+		ip, mac, err := subnet.GetStaticAddress(podName, IP(ip), mac, false)
+		klog.Infof("allocate %s %s for %s", ip, mac, podName)
+		return string(ip), mac, err
+	}
+}
+
+func (ipam *IPAM) ReleaseAddressByPod(podName string) {
+	ipam.mutex.RLock()
+	defer ipam.mutex.RUnlock()
+	for _, subnet := range ipam.Subnets {
+		ip, mac := subnet.ReleaseAddress(podName)
+		klog.Infof("release %s %s for %s", ip, mac, podName)
+	}
+	return
+}
+
+func (ipam *IPAM) AddOrUpdateSubnet(name, cidrStr string, excludeIps []string) error {
+	ipam.mutex.Lock()
+	defer ipam.mutex.Unlock()
+
+	_, _, err := net.ParseCIDR(cidrStr)
+	if err != nil {
+		return InvalidCIDRError
+	}
+
+	if subnet, ok := ipam.Subnets[name]; ok {
+		subnet.ReservedIPList = convertExcludeIps(excludeIps)
+		firstIP, _ := util.FirstSubnetIP(cidrStr)
+		lastIP, _ := util.LastSubnetIP(cidrStr)
+		subnet.FreeIPList = IPRangeList{&IPRange{Start: IP(firstIP), End: IP(lastIP)}}
+		subnet.joinFreeWithReserve()
+		for podName, ip := range subnet.PodToIP {
+			mac := subnet.PodToMac[podName]
+			if _, _, err := subnet.GetStaticAddress(podName, ip, mac, true); err != nil {
+				klog.Errorf("%s address not in subnet %s new cidr %s", podName, name, cidrStr)
+			}
+		}
+		return nil
+	}
+
+	subnet, err := NewSubnet(name, cidrStr, excludeIps)
+	if err != nil {
+		return err
+	}
+	ipam.Subnets[name] = subnet
+	return nil
+}
+
+func (ipam *IPAM) DeleteSubnet(subnetName string) {
+	ipam.mutex.Lock()
+	defer ipam.mutex.Unlock()
+	delete(ipam.Subnets, subnetName)
+}
+
+func (ipam *IPAM) GetPodAddress(podName string) (string, string, bool) {
+	ipam.mutex.RLock()
+	defer ipam.mutex.RUnlock()
+	for _, subnet := range ipam.Subnets {
+		if ip, mac, exist := subnet.GetPodAddress(podName); exist {
+			return string(ip), mac, exist
+		}
+	}
+	return "", "", false
+}

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -1,0 +1,179 @@
+package ipam
+
+import (
+	"github.com/alauda/kube-ovn/pkg/util"
+	"net"
+	"sync"
+)
+
+type Subnet struct {
+	Name           string
+	mutex          sync.RWMutex
+	CIDR           *net.IPNet
+	FreeIPList     IPRangeList
+	ReservedIPList IPRangeList
+	PodToIP        map[string]IP
+	IPToPod        map[IP]string
+	PodToMac       map[string]string
+	MacToPod       map[string]string
+}
+
+func NewSubnet(name, cidrStr string, excludeIps []string) (*Subnet, error) {
+	_, cidr, err := net.ParseCIDR(cidrStr)
+	if err != nil {
+		return nil, InvalidCIDRError
+	}
+
+	firstIP, _ := util.FirstSubnetIP(cidrStr)
+	lastIP, _ := util.LastSubnetIP(cidrStr)
+
+	subnet := Subnet{
+		Name:           name,
+		mutex:          sync.RWMutex{},
+		CIDR:           cidr,
+		FreeIPList:     IPRangeList{&IPRange{Start: IP(firstIP), End: IP(lastIP)}},
+		ReservedIPList: convertExcludeIps(excludeIps),
+		PodToIP:        map[string]IP{},
+		IPToPod:        map[IP]string{},
+		MacToPod:       map[string]string{},
+		PodToMac:       map[string]string{},
+	}
+	subnet.joinFreeWithReserve()
+	return &subnet, nil
+}
+
+func (subnet *Subnet) GetRandomMac(podName string) string {
+	if mac, ok := subnet.PodToMac[podName]; ok {
+		return mac
+	}
+	for {
+		mac := util.GenerateMac()
+		if _, ok := subnet.MacToPod[mac]; !ok {
+			subnet.MacToPod[mac] = podName
+			subnet.PodToMac[podName] = mac
+			return mac
+		}
+	}
+}
+
+func (subnet *Subnet) GetStaticMac(podName, mac string) error {
+	if p, ok := subnet.MacToPod[mac]; ok && p != podName {
+		return ConflictError
+	}
+	subnet.MacToPod[mac] = podName
+	subnet.PodToMac[podName] = mac
+	return nil
+}
+
+func (subnet *Subnet) GetRandomAddress(podName string) (IP, string, error) {
+	subnet.mutex.Lock()
+	defer subnet.mutex.Unlock()
+	if ip, ok := subnet.PodToIP[podName]; ok {
+		return ip, subnet.PodToMac[podName], nil
+	}
+	if len(subnet.FreeIPList) == 0 {
+		return "", "", NoAvailableError
+	}
+	freeList := subnet.FreeIPList
+	ipr := freeList[0]
+	ip := ipr.Start
+	newStart := ip.Add(1)
+	if newStart.LessThan(ipr.End) || newStart.Equal(ipr.End) {
+		ipr.Start = newStart
+	} else {
+		subnet.FreeIPList = subnet.FreeIPList[1:]
+	}
+	subnet.PodToIP[podName] = ip
+	subnet.IPToPod[ip] = podName
+	return ip, subnet.GetRandomMac(podName), nil
+}
+
+func (subnet *Subnet) GetStaticAddress(podName string, ip IP, mac string, force bool) (IP, string, error) {
+	subnet.mutex.Lock()
+	subnet.mutex.Unlock()
+	if !subnet.CIDR.Contains(net.ParseIP(string(ip))) {
+		return ip, mac, OutOfRangeError
+	}
+
+	if mac == "" {
+		if m, ok := subnet.PodToMac[mac]; ok {
+			mac = m
+		} else {
+			mac = subnet.GetRandomMac(podName)
+		}
+	} else {
+		if err := subnet.GetStaticMac(podName, mac); err != nil {
+			return ip, mac, err
+		}
+	}
+
+	if existPod, ok := subnet.IPToPod[ip]; ok {
+		if existPod != podName {
+			return ip, mac, ConflictError
+		}
+		if !force {
+			return ip, mac, nil
+		}
+	}
+
+	if subnet.ReservedIPList.Contains(ip) {
+		subnet.PodToIP[podName] = ip
+		subnet.IPToPod[ip] = podName
+		return ip, mac, nil
+	}
+
+	if split, newFreeList := splitIPRangeList(subnet.FreeIPList, ip); split {
+		subnet.FreeIPList = newFreeList
+		subnet.PodToIP[podName] = ip
+		subnet.IPToPod[ip] = podName
+		return ip, mac, nil
+	} else {
+		return ip, mac, NoAvailableError
+	}
+}
+
+func (subnet *Subnet) ReleaseAddress(podName string) (IP, string) {
+	subnet.mutex.Lock()
+	defer subnet.mutex.Unlock()
+	ip, mac := IP(""), ""
+	var ok bool
+	if ip, ok = subnet.PodToIP[podName]; ok {
+		delete(subnet.PodToIP, podName)
+		delete(subnet.IPToPod, ip)
+		if mac, ok = subnet.PodToMac[podName]; ok {
+			delete(subnet.PodToMac, podName)
+			delete(subnet.MacToPod, mac)
+		}
+
+		if !subnet.CIDR.Contains(net.ParseIP(string(ip))) {
+			return ip, mac
+		}
+
+		if subnet.ReservedIPList.Contains(ip) {
+			return ip, mac
+		}
+
+		if merged, newFreeList := mergeIPRangeList(subnet.FreeIPList, ip); merged {
+			subnet.FreeIPList = newFreeList
+			return ip, mac
+		}
+	}
+	return ip, mac
+}
+
+func (subnet *Subnet) joinFreeWithReserve() {
+	for _, reserveIpr := range subnet.ReservedIPList {
+		newFreeList := IPRangeList{}
+		for _, freeIpr := range subnet.FreeIPList {
+			if iprl := splitRange(freeIpr, reserveIpr); iprl != nil {
+				newFreeList = append(newFreeList, iprl...)
+			}
+		}
+		subnet.FreeIPList = newFreeList
+	}
+}
+
+func (subnet *Subnet) GetPodAddress(podName string) (IP, string, bool) {
+	ip, mac := subnet.PodToIP[podName], subnet.PodToMac[podName]
+	return ip, mac, (ip != "" && mac != "")
+}

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -43,6 +43,24 @@ func FirstSubnetIP(subnet string) (string, error) {
 	return BigInt2Ip(ipInt.Add(ipInt, big.NewInt(1))), nil
 }
 
+func LastSubnetIP(subnet string) (string, error) {
+	_, cidr, err := net.ParseCIDR(subnet)
+	if err != nil {
+		return "", fmt.Errorf("%s is not a valid cidr", subnet)
+	}
+	var length uint
+	if CheckProtocol(subnet) == kubeovnv1.ProtocolIPv4 {
+		length = 32
+	} else {
+		length = 128
+	}
+	maskLength, _ := cidr.Mask.Size()
+	ipInt := Ip2BigInt(cidr.IP.String())
+	size := big.NewInt(0).Lsh(big.NewInt(1), length-uint(maskLength))
+	size = big.NewInt(0).Sub(size, big.NewInt(2))
+	return BigInt2Ip(ipInt.Add(ipInt, size)), nil
+}
+
 func CIDRConflict(a, b string) bool {
 	aIp, aIpNet, aErr := net.ParseCIDR(a)
 	bIp, bIpNet, bErr := net.ParseCIDR(b)

--- a/test/e2e/ip/static_ip.go
+++ b/test/e2e/ip/static_ip.go
@@ -34,7 +34,7 @@ var _ = Describe("[IP Allocation]", func() {
 					Containers: []corev1.Container{
 						{
 							Name:            name,
-							Image:           "index.alauda.cn/library/nginx:alpine",
+							Image:           "index.alauda.cn/claas/pause:3.1",
 							ImagePullPolicy: corev1.PullIfNotPresent,
 						},
 					},
@@ -82,7 +82,7 @@ var _ = Describe("[IP Allocation]", func() {
 							Containers: []corev1.Container{
 								{
 									Name:            name,
-									Image:           "index.alauda.cn/library/nginx:alpine",
+									Image:           "index.alauda.cn/claas/pause:3.1",
 									ImagePullPolicy: corev1.PullIfNotPresent,
 								},
 							},
@@ -128,14 +128,14 @@ var _ = Describe("[IP Allocation]", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{"apps": name},
 							Annotations: map[string]string{
-								util.IpPoolAnnotation: "12.10.0.30, 12.10.0.31, 12.10.0.32",
+								util.IpPoolAnnotation: "12.10.0.31, 12.10.0.32, 12.10.0.30",
 							},
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
 									Name:            name,
-									Image:           "index.alauda.cn/library/nginx:alpine",
+									Image:           "index.alauda.cn/claas/pause:3.1",
 									ImagePullPolicy: corev1.PullIfNotPresent,
 								},
 							},
@@ -155,7 +155,7 @@ var _ = Describe("[IP Allocation]", func() {
 			for i := 0; i < 3; i++ {
 				pod, err := f.KubeClientSet.CoreV1().Pods(namespace).Get(fmt.Sprintf("%s-%d", name, i), metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(pod.Status.PodIP).To(Equal([]string{"12.10.0.30", "12.10.0.31", "12.10.0.32"}[i]))
+				Expect(pod.Status.PodIP).To(Equal([]string{"12.10.0.31", "12.10.0.32", "12.10.0.30"}[i]))
 			}
 		})
 	})

--- a/test/unittest/ipam/ipam.go
+++ b/test/unittest/ipam/ipam.go
@@ -1,0 +1,174 @@
+package ipam
+
+import (
+	"github.com/alauda/kube-ovn/pkg/ipam"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("[IPAM]", func() {
+	subnetName := "test"
+	cidrStr := "10.16.0.0/16"
+	excludeIps := []string{
+		"10.16.0.1",
+		"10.16.0.10..10.16.0.20",
+		"10.16.0.15..10.16.0.23",
+		"10.16.0.4",
+		"192.168.0.1..192.168.0.10",
+	}
+
+	Describe("[IPAM]", func() {
+		It("invalid subnet", func() {
+			im := ipam.NewIPAM()
+			err := im.AddOrUpdateSubnet("test", "1.1.1.1/64", []string{})
+			Expect(err).Should(MatchError(ipam.InvalidCIDRError))
+		})
+
+		It("normal subnet", func() {
+			im := ipam.NewIPAM()
+			err := im.AddOrUpdateSubnet(subnetName, cidrStr, excludeIps)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			_, _, err = im.GetStaticAddress("pod1.ns", "10.16.0.2", "", subnetName)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			ip, _, err := im.GetRandomAddress("pod1.ns", subnetName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ip).To(Equal("10.16.0.2"))
+
+			ip, _, err = im.GetRandomAddress("pod2.ns", subnetName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ip).To(Equal("10.16.0.3"))
+
+			_, _, err = im.GetStaticAddress("pod3.ns", "10.16.0.2", "", subnetName)
+			Expect(err).Should(MatchError(ipam.ConflictError))
+
+			im.ReleaseAddressByPod("pod1.ns")
+			_, _, err = im.GetStaticAddress("pod3.ns", "10.16.0.2", "", subnetName)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			_, _, err = im.GetRandomAddress("pod4.ns", "invalid_subnet")
+			Expect(err).Should(MatchError(ipam.NoAvailableError))
+
+			err = im.AddOrUpdateSubnet(subnetName, cidrStr, []string{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			ip, _, err = im.GetRandomAddress("pod5.ns", subnetName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ip).To(Equal("10.16.0.1"))
+
+			ip, _, exist := im.GetPodAddress("pod5.ns")
+			Expect(exist).To(BeTrue())
+			Expect(ip).To(Equal("10.16.0.1"))
+		})
+	})
+
+	Describe("[IP]", func() {
+		It("IP operation", func() {
+			ip1 := ipam.IP("10.0.0.16")
+			ip2 := ipam.IP("10.0.0.17")
+
+			Expect(ip1.Equal(ip1)).To(BeTrue())
+			Expect(ip1.GreaterThan(ip1)).To(BeFalse())
+			Expect(ip1.LessThan(ip1)).To(BeFalse())
+
+			Expect(ip1.Equal(ip2)).To(BeFalse())
+			Expect(ip1.GreaterThan(ip1)).To(BeFalse())
+			Expect(ip1.LessThan(ip2)).To(BeTrue())
+
+			Expect(ip1.Add(1)).To(Equal(ip2))
+			Expect(ip2.Add(-1)).To(Equal(ip1))
+		})
+	})
+
+	Describe("[Subnet]", func() {
+		It("init subnet", func() {
+			subnet, err := ipam.NewSubnet(subnetName, cidrStr, excludeIps)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(subnet.Name).To(Equal(subnetName))
+			Expect(subnet.ReservedIPList).To(HaveLen(len(excludeIps)))
+			Expect(subnet.FreeIPList).To(HaveLen(3))
+			Expect(subnet.FreeIPList).To(Equal(
+				ipam.IPRangeList{
+					&ipam.IPRange{Start: "10.16.0.2", End: "10.16.0.3"},
+					&ipam.IPRange{Start: "10.16.0.5", End: "10.16.0.9"},
+					&ipam.IPRange{Start: "10.16.0.24", End: "10.16.255.254"},
+				}))
+		})
+
+		It("static allocation", func() {
+			subnet, err := ipam.NewSubnet(subnetName, cidrStr, excludeIps)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, _, err = subnet.GetStaticAddress("pod1.ns", "10.16.0.2", "", false)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, _, err = subnet.GetStaticAddress("pod2.ns", "10.16.0.3", "", false)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, _, err = subnet.GetStaticAddress("pod3.ns", "10.16.0.20", "", false)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(subnet.FreeIPList).To(Equal(
+				ipam.IPRangeList{
+					&ipam.IPRange{Start: "10.16.0.5", End: "10.16.0.9"},
+					&ipam.IPRange{Start: "10.16.0.24", End: "10.16.255.254"},
+				}))
+
+			Expect(subnet.IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.2"), "pod1.ns"))
+			Expect(subnet.IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.3"), "pod2.ns"))
+			Expect(subnet.IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.20"), "pod3.ns"))
+			Expect(subnet.PodToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("10.16.0.2")))
+			Expect(subnet.PodToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("10.16.0.3")))
+			Expect(subnet.PodToIP).To(HaveKeyWithValue("pod3.ns", ipam.IP("10.16.0.20")))
+
+			_, _, err = subnet.GetStaticAddress("pod4.ns", "10.16.0.3", "", false)
+			Expect(err).Should(MatchError(ipam.ConflictError))
+			_, _, err = subnet.GetStaticAddress("pod5.ns", "19.16.0.3", "", false)
+			Expect(err).Should(MatchError(ipam.OutOfRangeError))
+
+			subnet.ReleaseAddress("pod1.ns")
+			subnet.ReleaseAddress("pod2.ns")
+			subnet.ReleaseAddress("pod3.ns")
+			Expect(subnet.FreeIPList).To(Equal(
+				ipam.IPRangeList{
+					&ipam.IPRange{Start: "10.16.0.2", End: "10.16.0.3"},
+					&ipam.IPRange{Start: "10.16.0.5", End: "10.16.0.9"},
+					&ipam.IPRange{Start: "10.16.0.24", End: "10.16.255.254"},
+				}))
+
+			Expect(subnet.PodToIP).To(BeEmpty())
+			Expect(subnet.IPToPod).To(BeEmpty())
+		})
+
+		It("random allocation", func() {
+			subnet, err := ipam.NewSubnet("test", "10.16.0.0/30", []string{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			ip1, _, err := subnet.GetRandomAddress("pod1.ns")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ip1).To(Equal(ipam.IP("10.16.0.1")))
+			ip1, _, err = subnet.GetRandomAddress("pod1.ns")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ip1).To(Equal(ipam.IP("10.16.0.1")))
+
+			ip2, _, err := subnet.GetRandomAddress("pod2.ns")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ip2).To(Equal(ipam.IP("10.16.0.2")))
+
+			_, _, err = subnet.GetRandomAddress("pod3.ns")
+			Expect(err).Should(MatchError(ipam.NoAvailableError))
+			Expect(subnet.FreeIPList).To(BeEmpty())
+
+			Expect(subnet.IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.1"), "pod1.ns"))
+			Expect(subnet.IPToPod).To(HaveKeyWithValue(ipam.IP("10.16.0.2"), "pod2.ns"))
+			Expect(subnet.PodToIP).To(HaveKeyWithValue("pod1.ns", ipam.IP("10.16.0.1")))
+			Expect(subnet.PodToIP).To(HaveKeyWithValue("pod2.ns", ipam.IP("10.16.0.2")))
+
+			subnet.ReleaseAddress("pod1.ns")
+			subnet.ReleaseAddress("pod2.ns")
+			Expect(subnet.FreeIPList).To(Equal(
+				ipam.IPRangeList{
+					&ipam.IPRange{Start: "10.16.0.1", End: "10.16.0.2"},
+				}))
+			Expect(subnet.IPToPod).To(BeEmpty())
+			Expect(subnet.PodToIP).To(BeEmpty())
+		})
+	})
+})

--- a/test/unittest/unit_suite_test.go
+++ b/test/unittest/unit_suite_test.go
@@ -1,0 +1,16 @@
+package unittest
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	// tests to run
+	_ "github.com/alauda/kube-ovn/test/unittest/ipam"
+)
+
+func TestE2e(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kube-OVN unit test Suite")
+}


### PR DESCRIPTION
Use kube-ovn ipam to replace ovn dynamic address allocation. We will design more flexible ip allocation strategy and provide ipam capacity to other cni plugin later.