### PR TITLE
OVS local interface table mac_in_use col is in lower case, but pod

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -862,6 +862,7 @@ tcpdump(){
      echo "pod mac address not ready"
      exit 1
   fi
+  mac=$(echo "$mac" | tr '[:upper:]' '[:lower:]')
 
   ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -o wide| grep kube-ovn-cni| grep " $nodeName " | awk '{print $1}')
   if [ -z "$ovnCni" ]; then

--- a/dist/images/kubectl-ko
+++ b/dist/images/kubectl-ko
@@ -39,6 +39,7 @@ tcpdump(){
      echo "pod mac address not ready"
      exit 1
   fi
+  mac=$(echo "$mac" | tr '[:upper:]' '[:lower:]')
 
   ovnCni=$(kubectl get pod -n $KUBE_OVN_NS -o wide| grep kube-ovn-cni| grep " $nodeName " | awk '{print $1}')
   if [ -z "$ovnCni" ]; then


### PR DESCRIPTION
annotation store mac in Upper case.
![image](https://user-images.githubusercontent.com/4113173/78822315-78519f00-7a0d-11ea-9d56-0e71798974fb.png)
