### PR TITLE
fix: concurrent panic

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -371,7 +371,7 @@ func (c *Controller) handleAddPod(key string) error {
 	if pod.Annotations[util.AllocatedAnnotation] == "true" &&
 		pod.Annotations[util.RoutedAnnotation] != "true" &&
 		pod.Spec.NodeName != "" {
-		return c.handleUpdatePod(key)
+		c.updatePodQueue.Add(key)
 	}
 
 	return nil

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -41,7 +41,6 @@ func ParseFlags() (*Configuration, error) {
 		argNeighborAs      = pflag.Uint32("neighbor-as", 65001, "The router as number, default 65001")
 		argPprofPort       = pflag.Uint32("pprof-port", 10667, "The port to get profiling data, default: 10667")
 		argKubeConfigFile  = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information. If not set use the inCluster token.")
-
 	)
 
 	flag.Set("alsologtostderr", "true")


### PR DESCRIPTION
Call handleUpdatePod directly may lead two workers handle the same pod and panic when write annotation at the same time.