### PR TITLE
Add OVS-DPDK support, for issue 104

### DIFF
--- a/dist/images/Dockerfile.dpdk1911
+++ b/dist/images/Dockerfile.dpdk1911
@@ -18,22 +18,17 @@ ENV DPDK_DIR=/usr/src/dpdk-stable-${DPDK_VERSION}
 ENV PATH=${PATH}:/usr/share/openvswitch/scripts
 ENV PATH=${PATH}:/usr/share/ovn/scripts/
 
-RUN dnf install -y wget xz git make numactl-devel diffutils dnf-plugins-core dpdk-devel libcap-ng-devel libpcap-devel nc iptables ipset hostname && dnf clean all
-
+RUN dnf install -y make numactl-devel diffutils dnf-plugins-core dpdk-devel libcap-ng-devel libpcap-devel nc iptables ipset hostname \
 # NOTE: Fedora 32 comes with gcc version 10. This caused LD linker issues during DPDK build.
 # Install gcc version 9 and its dependencies.
-RUN mkdir /rpms && cd /rpms
-RUN wget https://kojipkgs.fedoraproject.org//packages/gcc/9.2.1/1.fc32.3/x86_64/cpp-9.2.1-1.fc32.3.x86_64.rpm \
-         https://kojipkgs.fedoraproject.org//packages/gcc/9.2.1/1.fc32.3/x86_64/libgomp-9.2.1-1.fc32.3.x86_64.rpm \
-         https://kojipkgs.fedoraproject.org//packages/gcc/9.2.1/1.fc32.3/x86_64/gcc-9.2.1-1.fc32.3.x86_64.rpm
-RUN dnf install -y cpp-9.2.1-1.fc32.3.x86_64.rpm libgomp-9.2.1-1.fc32.3.x86_64.rpm gcc-9.2.1-1.fc32.3.x86_64.rpm
-RUN rm -f cpp-9.2.1-1.fc32.3.x86_64.rpm libgomp-9.2.1-1.fc32.3.x86_64.rpm gcc-9.2.1-1.fc32.3.x86_64.rpm
+  https://kojipkgs.fedoraproject.org//packages/gcc/9.2.1/1.fc32.3/x86_64/cpp-9.2.1-1.fc32.3.x86_64.rpm \
+  https://kojipkgs.fedoraproject.org//packages/gcc/9.2.1/1.fc32.3/x86_64/libgomp-9.2.1-1.fc32.3.x86_64.rpm \
+  https://kojipkgs.fedoraproject.org//packages/gcc/9.2.1/1.fc32.3/x86_64/gcc-9.2.1-1.fc32.3.x86_64.rpm && \
+  dnf clean all
 
 # Install DPDK
 RUN cd /usr/src/ && \
-  wget http://fast.dpdk.org/rel/dpdk-${DPDK_VERSION}.tar.xz && \
-  tar xf dpdk-${DPDK_VERSION}.tar.xz && \
-  rm -f dpdk-${DPDK_VERSION}.tar.xz && \
+  curl http://fast.dpdk.org/rel/dpdk-${DPDK_VERSION}.tar.gz | tar xz && \
   cd ${DPDK_DIR} && \
   sed -i s/CONFIG_RTE_EAL_IGB_UIO=y/CONFIG_RTE_EAL_IGB_UIO=n/ config/common_linux && \
   sed -i s/CONFIG_RTE_LIBRTE_KNI=y/CONFIG_RTE_LIBRTE_KNI=n/ config/common_linux && \
@@ -42,11 +37,9 @@ RUN cd /usr/src/ && \
 
 # Install OVS-DPDK
 # NOTE: rpm-build is installed here, as installing it earlier conflicts with the workaround to roll back the gcc version.
-RUN dnf install -y rpm-build
-RUN cd /usr/src/ && \
-  wget https://www.openvswitch.org/releases/openvswitch-${OVS_VERSION}.tar.gz && \
-  tar xf openvswitch-${OVS_VERSION}.tar.gz && \
-  rm -f openvswitch-${OVS_VERSION}.tar.gz && \
+RUN dnf install -y rpm-build && \
+  cd /usr/src/ && \
+  curl https://www.openvswitch.org/releases/openvswitch-${OVS_VERSION}.tar.gz | tar xz && \
   cd ${OVS_DIR} && \
   sed -e 's/@VERSION@/0.0.1/' rhel/openvswitch-fedora.spec.in > /tmp/ovs.spec && \
   dnf builddep -y /tmp/ovs.spec && \
@@ -56,17 +49,20 @@ RUN cd /usr/src/ && \
 
 # Install OVN
 RUN cd /usr/src/ && \
-  git clone -b branch-${OVN_VERSION} --depth=1 https://github.com/ovn-org/ovn.git && \
+  cd /usr/src/ && \
+  curl -L https://github.com/ovn-org/ovn/tarball/branch-${OVN_VERSION} > ovn.tar.gz && \
+  mkdir ovn && tar -xf ovn.tar.gz -C ovn --strip-components 1 && \
+  rm -f ovn.tar.gz && \
   cd ovn && \
   ./boot.sh && \
   ./configure --with-ovs-source=${OVS_DIR} && \
   make rpm-fedora
 
-RUN cp ${OVS_DIR}/rpm/rpmbuild/RPMS/${RPM_ARCH}/* ${OVN_DIR}/rpm/rpmbuild/RPMS/${RPM_ARCH}/* /rpms
-
 RUN mkdir -p /var/run/openvswitch && \
-    mkdir -p /var/run/ovn
-
-RUN rpm -ivh --nodeps /rpms/*.rpm
+  mkdir -p /var/run/ovn && \
+  mkdir -p /rpms && \
+  cp ${OVS_DIR}/rpm/rpmbuild/RPMS/${RPM_ARCH}/* ${OVN_DIR}/rpm/rpmbuild/RPMS/${RPM_ARCH}/* /rpms && \
+  rpm -ivh --nodeps /rpms/*.rpm && \
+  rm -rf ${OVN_DIR} ${OVS_DIR} ${DPDK_DIR}
 
 COPY *.sh /kube-ovn/

--- a/dist/images/Dockerfile.dpdk1911
+++ b/dist/images/Dockerfile.dpdk1911
@@ -1,0 +1,72 @@
+# NOTE: At time of writing, CentOS 8 does not have dpdk-devel v19.11 in the Yum repo.
+# This package is required to build the OVS-DPDK RPMs and is available in Fedora 32.
+FROM fedora:32
+
+ENV RPM_ARCH=x86_64
+ENV ARCH=amd64
+
+ENV OVN_VERSION=20.03
+ENV OVS_VERSION=2.13.0
+
+ENV DPDK_VERSION=19.11.1
+ENV DPDK_TARGET=x86_64-native-linuxapp-gcc
+
+ENV OVN_DIR=/usr/src/ovn
+ENV OVS_DIR=/usr/src/openvswitch-${OVS_VERSION}
+ENV DPDK_DIR=/usr/src/dpdk-stable-${DPDK_VERSION}
+
+ENV PATH=${PATH}:/usr/share/openvswitch/scripts
+ENV PATH=${PATH}:/usr/share/ovn/scripts/
+
+RUN dnf install -y wget xz git make numactl-devel diffutils dnf-plugins-core dpdk-devel libcap-ng-devel libpcap-devel nc iptables ipset hostname && dnf clean all
+
+# NOTE: Fedora 32 comes with gcc version 10. This caused LD linker issues during DPDK build.
+# Install gcc version 9 and its dependencies.
+RUN mkdir /rpms && cd /rpms
+RUN wget https://kojipkgs.fedoraproject.org//packages/gcc/9.2.1/1.fc32.3/x86_64/cpp-9.2.1-1.fc32.3.x86_64.rpm \
+         https://kojipkgs.fedoraproject.org//packages/gcc/9.2.1/1.fc32.3/x86_64/libgomp-9.2.1-1.fc32.3.x86_64.rpm \
+         https://kojipkgs.fedoraproject.org//packages/gcc/9.2.1/1.fc32.3/x86_64/gcc-9.2.1-1.fc32.3.x86_64.rpm
+RUN dnf install -y cpp-9.2.1-1.fc32.3.x86_64.rpm libgomp-9.2.1-1.fc32.3.x86_64.rpm gcc-9.2.1-1.fc32.3.x86_64.rpm
+RUN rm -f cpp-9.2.1-1.fc32.3.x86_64.rpm libgomp-9.2.1-1.fc32.3.x86_64.rpm gcc-9.2.1-1.fc32.3.x86_64.rpm
+
+# Install DPDK
+RUN cd /usr/src/ && \
+  wget http://fast.dpdk.org/rel/dpdk-${DPDK_VERSION}.tar.xz && \
+  tar xf dpdk-${DPDK_VERSION}.tar.xz && \
+  rm -f dpdk-${DPDK_VERSION}.tar.xz && \
+  cd ${DPDK_DIR} && \
+  sed -i s/CONFIG_RTE_EAL_IGB_UIO=y/CONFIG_RTE_EAL_IGB_UIO=n/ config/common_linux && \
+  sed -i s/CONFIG_RTE_LIBRTE_KNI=y/CONFIG_RTE_LIBRTE_KNI=n/ config/common_linux && \
+  sed -i s/CONFIG_RTE_KNI_KMOD=y/CONFIG_RTE_KNI_KMOD=n/ config/common_linux && \
+  make install T=${DPDK_TARGET} DESTDIR=install
+
+# Install OVS-DPDK
+# NOTE: rpm-build is installed here, as installing it earlier conflicts with the workaround to roll back the gcc version.
+RUN dnf install -y rpm-build
+RUN cd /usr/src/ && \
+  wget https://www.openvswitch.org/releases/openvswitch-${OVS_VERSION}.tar.gz && \
+  tar xf openvswitch-${OVS_VERSION}.tar.gz && \
+  rm -f openvswitch-${OVS_VERSION}.tar.gz && \
+  cd ${OVS_DIR} && \
+  sed -e 's/@VERSION@/0.0.1/' rhel/openvswitch-fedora.spec.in > /tmp/ovs.spec && \
+  dnf builddep -y /tmp/ovs.spec && \
+  ./boot.sh && \
+  ./configure --prefix=/usr/ --with-dpdk=${DPDK_DIR}/${DPDK_TARGET} && \
+  make rpm-fedora RPMBUILD_OPT="--with dpdk --without check"
+
+# Install OVN
+RUN cd /usr/src/ && \
+  git clone -b branch-${OVN_VERSION} --depth=1 https://github.com/ovn-org/ovn.git && \
+  cd ovn && \
+  ./boot.sh && \
+  ./configure --with-ovs-source=${OVS_DIR} && \
+  make rpm-fedora
+
+RUN cp ${OVS_DIR}/rpm/rpmbuild/RPMS/${RPM_ARCH}/* ${OVN_DIR}/rpm/rpmbuild/RPMS/${RPM_ARCH}/* /rpms
+
+RUN mkdir -p /var/run/openvswitch && \
+    mkdir -p /var/run/ovn
+
+RUN rpm -ivh --nodeps /rpms/*.rpm
+
+COPY *.sh /kube-ovn/

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -20,6 +20,48 @@ VLAN_NAME="ovn-vlan"
 VLAN_ID="100"
 VLAN_RANGE="1,4095"
 
+# DPDK
+DPDK="false"
+DPDK_SUPPORTED_VERSIONS=("19.11")
+DPDK_VERSION=""
+
+display_help() {
+    echo "Usage: $0 [option...]"
+    echo
+    echo "  -h, --help               Print Help (this message) and exit"
+    echo "  --with-dpdk=<version>    Install Kube-OVN with OVS-DPDK instead of kernel OVS"
+    echo
+    exit 0
+}
+
+if [ -n "${1-}" ]
+then
+  set +u
+  while :; do
+    case $1 in
+      -h|--help)
+        display_help
+      ;;
+      --with-dpdk=*)
+        DPDK=true
+        DPDK_VERSION="${1#*=}"
+        if [[ ! "${DPDK_SUPPORTED_VERSIONS[@]}" = "${DPDK_VERSION}" ]] || [[ -z "${DPDK_VERSION}" ]]; then
+          echo "Unsupported DPDK version: ${DPDK_VERSION}"
+          echo "Supported DPDK versions: ${DPDK_SUPPORTED_VERSIONS[*]}"
+          exit 1
+        fi
+      ;;
+      -?*) 
+        echo "Unknown argument $1"
+        exit 1
+      ;;
+      *) break
+    esac
+    shift
+  done
+  set -u
+fi
+
 echo "[Step 1] Label kube-ovn-master node"
 count=$(kubectl get no -l$LABEL --no-headers -o wide | wc -l | sed 's/ //g')
 if [ "$count" = "0" ]; then
@@ -145,7 +187,12 @@ spec:
       JSONPath: .spec.subnet
 EOF
 
-cat <<EOF > ovn.yaml
+if $DPDK; then
+# TODO: Once kube-ovn-dpdk image is built and hosted on the registry
+# update the pod image 
+# from: "garyloug/kube-ovn-dpdk:$DPDK_VERSION"
+# to: "$REGISTRY/kube-ovn-dpdk:$DPDK_VERSION" 
+  cat <<EOF > ovn.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -418,6 +465,360 @@ spec:
       hostPID: true
       containers:
         - name: openvswitch
+          image: "garyloug/kube-ovn-dpdk:$DPDK_VERSION"
+          imagePullPolicy: $IMAGE_PULL_POLICY
+          command: ["/kube-ovn/start-ovs-dpdk.sh"]
+          securityContext:
+            runAsUser: 0
+            privileged: true
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: host-modules
+              readOnly: true
+            - mountPath: /var/run/openvswitch
+              name: host-run-ovs
+            - mountPath: /var/run/ovn
+              name: host-run-ovn
+            - mountPath: /sys
+              name: host-sys
+              readOnly: true
+            - mountPath: /etc/openvswitch
+              name: host-config-openvswitch
+            - mountPath: /etc/ovn
+              name: host-config-ovn
+            - mountPath: /var/log/openvswitch
+              name: host-log-ovs
+            - mountPath: /var/log/ovn
+              name: host-log-ovn
+            - mountPath: /dev/hugepages
+              name: hugepage
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - /kube-ovn/ovs-dpdk-healthcheck.sh
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - /kube-ovn/ovs-dpdk-healthcheck.sh
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2Gi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+              hugepages-1Gi: 1Gi
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      volumes:
+        - name: host-modules
+          hostPath:
+            path: /lib/modules
+        - name: host-run-ovs
+          hostPath:
+            path: /run/openvswitch
+        - name: host-run-ovn
+          hostPath:
+            path: /run/ovn
+        - name: host-sys
+          hostPath:
+            path: /sys
+        - name: host-config-openvswitch
+          hostPath:
+            path: /etc/origin/openvswitch
+        - name: host-config-ovn
+          hostPath:
+            path: /etc/origin/ovn
+        - name: host-log-ovs
+          hostPath:
+            path: /var/log/openvswitch
+        - name: host-log-ovn
+          hostPath:
+            path: /var/log/ovn
+        - name: hugepage
+          emptyDir:
+            medium: HugePages
+EOF
+
+else
+  cat <<EOF > ovn.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ovn-config
+  namespace: ${NAMESPACE}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovn
+  namespace:  ${NAMESPACE}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.k8s.io/system-only: "true"
+  name: system:ovn
+rules:
+  - apiGroups:
+      - "kubeovn.io"
+    resources:
+      - subnets
+      - subnets/status
+      - ips
+      - vlans
+      - networks
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - namespaces
+      - nodes
+      - configmaps
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - ""
+      - networking.k8s.io
+      - apps
+      - extensions
+    resources:
+      - networkpolicies
+      - services
+      - endpoints
+      - statefulsets
+      - daemonsets
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovn
+roleRef:
+  name: system:ovn
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: ovn
+    namespace:  ${NAMESPACE}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ovn-nb
+  namespace:  ${NAMESPACE}
+spec:
+  ports:
+    - name: ovn-nb
+      protocol: TCP
+      port: 6641
+      targetPort: 6641
+  type: ClusterIP
+  selector:
+    app: ovn-central
+    ovn-nb-leader: "true"
+  sessionAffinity: None
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ovn-sb
+  namespace:  ${NAMESPACE}
+spec:
+  ports:
+    - name: ovn-sb
+      protocol: TCP
+      port: 6642
+      targetPort: 6642
+  type: ClusterIP
+  selector:
+    app: ovn-central
+    ovn-sb-leader: "true"
+  sessionAffinity: None
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ovn-central
+  namespace:  ${NAMESPACE}
+  annotations:
+    kubernetes.io/description: |
+      OVN components: northd, nb and sb.
+spec:
+  replicas: $count
+  strategy:
+    rollingUpdate:
+      maxSurge: 0%
+      maxUnavailable: 100%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ovn-central
+  template:
+    metadata:
+      labels:
+        app: ovn-central
+        component: network
+        type: infra
+    spec:
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: ovn-central
+              topologyKey: kubernetes.io/hostname
+      priorityClassName: system-cluster-critical
+      serviceAccountName: ovn
+      hostNetwork: true
+      containers:
+        - name: ovn-central
+          image: "$REGISTRY/kube-ovn:$VERSION"
+          imagePullPolicy: $IMAGE_PULL_POLICY
+          command: ["/kube-ovn/start-db.sh"]
+          securityContext:
+            capabilities:
+              add: ["SYS_NICE"]
+          env:
+            - name: NODE_IPS
+              value: $addresses
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            requests:
+              cpu: 500m
+              memory: 300Mi
+          volumeMounts:
+            - mountPath: /var/run/openvswitch
+              name: host-run-ovs
+            - mountPath: /var/run/ovn
+              name: host-run-ovn
+            - mountPath: /sys
+              name: host-sys
+              readOnly: true
+            - mountPath: /etc/openvswitch
+              name: host-config-openvswitch
+            - mountPath: /etc/ovn
+              name: host-config-ovn
+            - mountPath: /var/log/openvswitch
+              name: host-log-ovs
+            - mountPath: /var/log/ovn
+              name: host-log-ovn
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - /kube-ovn/ovn-is-leader.sh
+            periodSeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - /kube-ovn/ovn-healthcheck.sh
+            initialDelaySeconds: 30
+            periodSeconds: 7
+            failureThreshold: 5
+      nodeSelector:
+        kubernetes.io/os: "linux"
+        kube-ovn/role: "master"
+      volumes:
+        - name: host-run-ovs
+          hostPath:
+            path: /run/openvswitch
+        - name: host-run-ovn
+          hostPath:
+            path: /run/ovn
+        - name: host-sys
+          hostPath:
+            path: /sys
+        - name: host-config-openvswitch
+          hostPath:
+            path: /etc/origin/openvswitch
+        - name: host-config-ovn
+          hostPath:
+            path: /etc/origin/ovn
+        - name: host-log-ovs
+          hostPath:
+            path: /var/log/openvswitch
+        - name: host-log-ovn
+          hostPath:
+            path: /var/log/ovn
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovs-ovn
+  namespace:  ${NAMESPACE}
+  annotations:
+    kubernetes.io/description: |
+      This daemon set launches the openvswitch daemon.
+spec:
+  selector:
+    matchLabels:
+      app: ovs
+  updateStrategy:
+    type: OnDelete
+  template:
+    metadata:
+      labels:
+        app: ovs
+        component: network
+        type: infra
+    spec:
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      priorityClassName: system-cluster-critical
+      serviceAccountName: ovn
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: openvswitch
           image: "$REGISTRY/kube-ovn:$VERSION"
           imagePullPolicy: $IMAGE_PULL_POLICY
           command: ["/kube-ovn/start-ovs.sh"]
@@ -497,6 +898,7 @@ spec:
           hostPath:
             path: /var/log/ovn
 EOF
+fi
 
 kubectl apply -f kube-ovn-crd.yaml
 kubectl apply -f ovn.yaml

--- a/dist/images/ovs-dpdk-healthcheck.sh
+++ b/dist/images/ovs-dpdk-healthcheck.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+ovs-ctl status
+ovs-vsctl get Open_vSwitch . dpdk_initialized
+ovn-ctl status_controller

--- a/dist/images/start-ovs-dpdk.sh
+++ b/dist/images/start-ovs-dpdk.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+function quit {
+	ovs-ctl stop
+	ovn-ctl stop_controller
+	exit 0
+}
+trap quit EXIT
+
+# Start ovsdb and vswitchd
+ovs-ctl --no-ovs-vswitchd start
+ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-socket-mem="1024"
+ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-init=true
+ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-hugepage-dir=/dev/hugepages
+ovs-ctl --no-ovsdb-server start
+
+# Start ovn-controller
+ovn-ctl restart_controller
+
+# Set remote ovn-sb for ovn-controller to connect to
+ovs-vsctl set open . external-ids:ovn-remote=tcp:"${OVN_SB_SERVICE_HOST}":"${OVN_SB_SERVICE_PORT}"
+ovs-vsctl set open . external-ids:ovn-remote-probe-interval=10000
+ovs-vsctl set open . external-ids:ovn-openflow-probe-interval=180
+ovs-vsctl set open . external-ids:ovn-encap-type=geneve
+
+tail -f /var/log/openvswitch/ovs-vswitchd.log

--- a/docs/dpdk.md
+++ b/docs/dpdk.md
@@ -1,0 +1,194 @@
+# Kube-OVN with OVS-DPDK
+
+This document describes how to run Kube-OVN with OVS-DPDK.
+
+
+## Prerequest
+- Kubernetes >= 1.11
+- Docker >= 1.12.6
+- OS: CentOS 7.5/7.6/7.7, Ubuntu 16.04/18.04
+
+
+## To Install
+
+<!---
+NOTE: Once  PR is merged, it should no longer be necessary to clone the repo.
+It should be possible to wget and run the install script as described in the Kube-OVN install document:
+https://github.com/alauda/kube-ovn/blob/master/docs/install.md
+
+TODO: Update once PR is merged.
+-->
+
+1. Clone the Kube-OVN repo
+`git clone https://github.com/alauda/kube-ovn.git`
+
+2. Navigate to the directory containing the install script
+`cd kube-ovn/dist/images/`
+
+3. Run the install script making sure to include the flag --with-dpdk= followed by the required DPDK version.  
+`bash install.sh --with-dpdk=19.11`
+>**Note:** Current supported version is DPDK 19.11
+
+
+## Multus
+The DPDK enabled vhost-user sockets provided by OVS-DPDK are not suitable for use as the default network of a Kubernetes pod. We must retain the OVS (kernel) interface provided by Kube-OVN and the DPDK socket(s) must be requested as additional interface(s).
+
+To facilitate multiple network interfaces to a pod we can use the [Multus-CNI](https://github.com/intel/multus-cni/) plugin.
+To install Multus follow the [Multus quick start guide](https://github.com/intel/multus-cni/blob/master/doc/quickstart.md#installation). During installation, Multus should detect Kube-OVN has already been installed as the default Kubernetes network plugin and will automatically configure itself so Kube-OVN continues to be the default network plugin for all pods.
+> **Note:** Multus determines the existing default network as the lexicographically (alphabetically) first configuration file in the /etc/cni/net.d directory.
+> If another plugin has the lexicographically first config file at this location, it will be considered the default network. Rename configuration files accordingly before Multus installation.
+
+With Multus installed, additional Network interfaces can now be requested within a pod spec. 
+ 
+ 
+## Userspace CNI
+There is now a containerized instance of OVS-DPDK running on the node. Kube-OVN can provide all of its regular (kernal) functionality. Multus is in place to enable pods request the additional OVS-DPDK interfaces. However, OVS-DPDK does provide regular Netdev interfaces, but vhost-user sockets. These sockets cannot be attached to a pod in the usual manner where the Netdev is moved to the pod network namespace. These sockets must be mounted into the pod. Kube-OVN (at least currently) does not have this socket-mounting ability. For this functionality we can use the [Userspace CNI Network Plugin](https://github.com/intel/userspace-cni-network-plugin). 
+
+### Download, build and install Userspace CNI
+>**Note:** These steps assume Go is already installed and the GOPATH env var is set.
+1. `go get github.com/intel/userspace-cni-network-plugin`
+2. `cd $GOPATH/src/github.com/intel/userspace-cni-network-plugin`
+4. `make clean`
+5. `make install`
+6. `make`
+7. `cp userspace/userspace /opt/cni/bin`
+
+### Userspace Network Attachment Definition
+A NetworkAttachmentDefinition is used to represent the network attachments. In this case we need a NAD to represent the network interfaces provided by Userspace CNI, i.e. the OVS-DPDK interfaces. It will then be possible to request this network attachment within a pod spec and Multus will attach these to the pod as secondary interfaces in addition to the preconfigured default network, i.e. the Kube-OVN provided OVS (Kernel) interfaces.
+
+Create the NetworkAttachmentDefinition
+```
+cat <<EOF | kubectl create -f -
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ovs-dpdk-br0
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "userspace",
+      "name": "ovs-dpdk-br0",
+      "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig",
+      "logFile": "/var/log/userspace-ovs-dpdk-br0.log",
+      "logLevel": "debug",
+      "host": {
+        "engine": "ovs-dpdk",
+        "iftype": "vhostuser",
+        "netType": "bridge",
+        "vhost": {
+          "mode": "server"
+        },
+        "bridge": {
+          "bridgeName": "br0"
+        }
+      },
+      "container": {
+        "engine": "ovs-dpdk",
+        "iftype": "vhostuser",
+        "netType": "interface",
+        "vhost": {
+          "mode": "client"
+        }
+      }
+    }
+EOF
+```
+It should now be possible to request the Userspace CNI provided interfaces as annotations within a pod spec. The example below will request two OVS-DPDK interfaces, these will be in addition to the default network.
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/networks: ovs-dpdk-br0, ovs-dpdk-br0
+```
+
+
+### Enable Userspace CNI to access containerized OVS-DPDK
+Userspace-CNI is intended to run in an environment where OVS-DPDK is installed directly on the host, rather than in a container. Userspace-CNI makes calls to OVS-DPDK using an application called ovs-vsctl. With a containerized OVS-DPDK, this application is no longer available on the host. The following is a workaround to take ovs-vsctl calls made from the host and direct them to the appropriate Kube-OVN container running OVS-DPDK.
+```
+cat <<'EOF' > /usr/local/bin/ovs-vsctl
+#!/bin/bash
+ovsCont=$(docker ps | grep kube-ovn | grep ovs-ovn | grep -v pause | awk '{print $1}')
+docker exec $ovsCont ovs-vsctl $@
+EOF
+```
+`chmod +x /usr/local/bin/ovs-vsctl`
+
+# Example DPDK Pod
+A sample Kubernetes pod running a DPDK enabled Docker image.
+### Dockerfile
+Create the Dockerfile, name it Dockerfile.dpdk
+```
+FROM centos:8
+
+ENV DPDK_VERSION=19.11.1
+ENV DPDK_TARGET=x86_64-native-linuxapp-gcc
+ENV DPDK_DIR=/usr/src/dpdk-stable-${DPDK_VERSION}
+
+RUN dnf groupinstall -y 'Development Tools'
+RUN dnf install -y wget numactl-devel
+
+RUN cd /usr/src/ && \
+  wget http://fast.dpdk.org/rel/dpdk-${DPDK_VERSION}.tar.xz && \
+  tar xf dpdk-${DPDK_VERSION}.tar.xz && \
+  rm -f dpdk-${DPDK_VERSION}.tar.xz && \
+  cd ${DPDK_DIR} && \
+  sed -i s/CONFIG_RTE_EAL_IGB_UIO=y/CONFIG_RTE_EAL_IGB_UIO=n/ config/common_linux && \
+  sed -i s/CONFIG_RTE_LIBRTE_KNI=y/CONFIG_RTE_LIBRTE_KNI=n/ config/common_linux && \
+  sed -i s/CONFIG_RTE_KNI_KMOD=y/CONFIG_RTE_KNI_KMOD=n/ config/common_linux && \
+  make install T=${DPDK_TARGET} DESTDIR=install
+```
+Build the Docker image and tag it as dpdk:19.11. This build will take some time.
+`docker build -t dpdk:19.11 -f Dockerfile.dpdk .`
+
+### Pod Spec
+Create the Pod Spec, name it pod.yaml
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: testpmd-dpdk-
+  annotations:
+    k8s.v1.cni.cncf.io/networks: ovs-dpdk-br0, ovs-dpdk-br0
+spec:
+  tolerations:
+  - operator: "Exists"
+    key: cmk
+  containers:
+  - name: testpmd-dpdk
+    image: dpdk:19.11
+    resources:
+      requests:
+        hugepages-1Gi: 2Gi
+        memory: 2Gi
+      limits:
+        hugepages-1Gi: 2Gi
+        memory: 2Gi
+    command: ["tail", "-f", "/dev/null"]
+    volumeMounts:
+    - mountPath: /hugepages
+      name: hugepages
+    - mountPath: /vhu
+      name: vhu
+    securityContext:
+        privileged: true
+        runAsUser: 0
+  volumes:
+  - name: hugepages
+    emptyDir:
+      medium: HugePages
+  - name: vhu
+    hostPath:
+      path: /var/run/openvswitch
+  securityContext:
+    runAsUser: 0
+  restartPolicy: Never
+```
+Run the pod.
+`kubectl create -f pod.yaml`
+
+The pod will be created with a kernel OVS interface provided by Kube-OVN, as the default network. In addition two secondary interfaces will be available within the pod as socket files located under /vhu/ .
+
+### TestPMD
+Steps to use the DPDK test application TestPMD appear to have changed slightly with the latest versions of OVS and DPDK. Updated instructions to follow shortly.


### PR DESCRIPTION
This commit adds OVS-DPDK support to Kube-OVN. User instructions are
included in a new file docs/dpdk.md

A new Dockerfile has been added to include OVS-DPDK along with OVN.
Where DPDK is required, this image is used for the ovs-ovn pod, in
place of the existing kernel-OVS “kube-ovn” image. This Dockerfile is
currently based on Fedora 32 for reasons noted as comments within the
file. It should later be possible to change this to CentOS when full
DPDK 19 support is available.

I recommend the above Dockerfile is built and tagged as
kube-ovn-dpdk:<version>, where the version corresponds to the DPDK
version used within the image (in this case 19:11) rather than the
Kube-OVN version. I recommend this as DPDK applications have a strong
dependency on DPDK version. If we force an end user to always use the
latest version, then we will likely break their DPDK app. I propose
over time we provide images for multiple DPDK versions and let the user
pick to suit their needs. I don’t see these images or Dockerfiles
requiring maintenance or support. They should be completely independent
of Kube-OVN versions and releases.

The install.sh script has been modified. It now takes a flag
--with-dpdk=<version> so the user can indicate they want to install
OVS-DPDK based on which version of DPDK. Version of DPDK required will
determine version of OVS and this will be already built into the Docker
image provided. The Kube-OVN version installed is still set at the top
of the script as the VERSION variable. This should still be the case
going forward, Kube-OVN and DPDK versions should operate independently
of each other. However, it’s something to watch. If future versions of
Kube-OVN have a strong dependency on newer versions of OVS, then the
older version of OVS used for DPDK may become an issue. We may have to
update the install script so a user wanting an older version of DPDK
has no choice but to use an older version of Kube-OVN that’s known to
be compatible. I don’t foresee this being an issue, but one to watch as
I said.

New startup and healthcheck scripts added for OVS-DPDK.