### PR TITLE
Config support for OVS-DPDK

### DIFF
--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -491,6 +491,8 @@ spec:
               name: host-log-ovs
             - mountPath: /var/log/ovn
               name: host-log-ovn
+            - mountPath: /opt/ovs-config
+              name: host-config-ovs
             - mountPath: /dev/hugepages
               name: hugepage
           readinessProbe:
@@ -542,6 +544,10 @@ spec:
         - name: host-log-ovn
           hostPath:
             path: /var/log/ovn
+        - name: host-config-ovs
+          hostPath:
+            path: /opt/ovs-config
+            type: DirectoryOrCreate
         - name: hugepage
           emptyDir:
             medium: HugePages

--- a/docs/dpdk.md
+++ b/docs/dpdk.md
@@ -32,6 +32,33 @@ Hugepagesize:    1048576 kB
 ```
 
 
+## Optional configuration
+
+Open vSwitch is highly configurable using `other_config` options as described in [Open vSwitch Manual](http://www.openvswitch.org/support/dist-docs/ovs-vswitchd.conf.db.5.txt).
+All of those configs can be configured using simple config file `/opt/ovs-config/config.cfg`. This file is being mounted in `ovs-ovn` pod. It contains list of `other_config` options. Each option should be placed in new line.
+
+Example:
+
+```
+dpdk-socket-mem="1024,1024"
+dpdk-init=true
+pmd-cpu-mask=0x4
+dpdk-lcore-mask=0x2
+dpdk-hugepage-dir=/dev/hugepages
+```
+
+This example config will enable DPDK support with 1024MB of hugepages for both NUMA node 0 and NUMA node 1, PMD CPU mask 0x4, lcore mask 0x2 and hugepages in /dev/hugepages.
+
+If file will not exist upon OVS initialization, the default configuration file will be created with values:
+
+```
+dpdk-socket-mem="1024"
+dpdk-init=true
+dpdk-hugepage-dir=/dev/hugepages
+```
+>**Note:** Please remember, that if you would like to initialize Open vSwitch with more socket memory than 1024MB, you will have to reserve this memory for `ovs-ovn` pod by editing the value `hugepages-1G` of `ovs-ovn` pod in `install.sh` script. For example, to initialize Open vSwitch using `dpdk-socket-mem="1024,1024"` the minimal value will be `hugepages-1G: 2Gi`.
+
+
 ## To Install
 
 1. Download the installation script:

--- a/yamls/ovn-dpdk.yaml
+++ b/yamls/ovn-dpdk.yaml
@@ -1,0 +1,363 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ovn-config
+  namespace: ${NAMESPACE}
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovn
+  namespace:  ${NAMESPACE}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.k8s.io/system-only: "true"
+  name: system:ovn
+rules:
+  - apiGroups:
+      - "kubeovn.io"
+    resources:
+      - subnets
+      - subnets/status
+      - ips
+      - vlans
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - namespaces
+      - nodes
+      - configmaps
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - ""
+      - networking.k8s.io
+      - apps
+      - extensions
+    resources:
+      - networkpolicies
+      - services
+      - endpoints
+      - statefulsets
+      - daemonsets
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovn
+roleRef:
+  name: system:ovn
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: ovn
+    namespace:  ${NAMESPACE}
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ovn-nb
+  namespace:  ${NAMESPACE}
+spec:
+  ports:
+    - name: ovn-nb
+      protocol: TCP
+      port: 6641
+      targetPort: 6641
+  type: ClusterIP
+  selector:
+    app: ovn-central
+    ovn-nb-leader: "true"
+  sessionAffinity: None
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ovn-sb
+  namespace:  ${NAMESPACE}
+spec:
+  ports:
+    - name: ovn-sb
+      protocol: TCP
+      port: 6642
+      targetPort: 6642
+  type: ClusterIP
+  selector:
+    app: ovn-central
+    ovn-sb-leader: "true"
+  sessionAffinity: None
+
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ovn-central
+  namespace:  ${NAMESPACE}
+  annotations:
+    kubernetes.io/description: |
+      OVN components: northd, nb and sb.
+spec:
+  replicas: $count
+  strategy:
+    rollingUpdate:
+      maxSurge: 0%
+      maxUnavailable: 100%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ovn-central
+  template:
+    metadata:
+      labels:
+        app: ovn-central
+        component: network
+        type: infra
+    spec:
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: ovn-central
+              topologyKey: kubernetes.io/hostname
+      priorityClassName: system-cluster-critical
+      serviceAccountName: ovn
+      hostNetwork: true
+      containers:
+        - name: ovn-central
+          image: "$REGISTRY/kube-ovn:$VERSION"
+          imagePullPolicy: $IMAGE_PULL_POLICY
+          command: ["/kube-ovn/start-db.sh"]
+          securityContext:
+            capabilities:
+              add: ["SYS_NICE"]
+          env:
+            - name: NODE_IPS
+              value: $addresses
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            requests:
+              cpu: 500m
+              memory: 300Mi
+          volumeMounts:
+            - mountPath: /var/run/openvswitch
+              name: host-run-ovs
+            - mountPath: /var/run/ovn
+              name: host-run-ovn
+            - mountPath: /sys
+              name: host-sys
+              readOnly: true
+            - mountPath: /etc/openvswitch
+              name: host-config-openvswitch
+            - mountPath: /etc/ovn
+              name: host-config-ovn
+            - mountPath: /var/log/openvswitch
+              name: host-log-ovs
+            - mountPath: /var/log/ovn
+              name: host-log-ovn
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - /kube-ovn/ovn-is-leader.sh
+            periodSeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - /kube-ovn/ovn-healthcheck.sh
+            initialDelaySeconds: 30
+            periodSeconds: 7
+            failureThreshold: 5
+      nodeSelector:
+        kubernetes.io/os: "linux"
+        kube-ovn/role: "master"
+      volumes:
+        - name: host-run-ovs
+          hostPath:
+            path: /run/openvswitch
+        - name: host-run-ovn
+          hostPath:
+            path: /run/ovn
+        - name: host-sys
+          hostPath:
+            path: /sys
+        - name: host-config-openvswitch
+          hostPath:
+            path: /etc/origin/openvswitch
+        - name: host-config-ovn
+          hostPath:
+            path: /etc/origin/ovn
+        - name: host-log-ovs
+          hostPath:
+            path: /var/log/openvswitch
+        - name: host-log-ovn
+          hostPath:
+            path: /var/log/ovn
+
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovs-ovn
+  namespace:  ${NAMESPACE}
+  annotations:
+    kubernetes.io/description: |
+      This daemon set launches the openvswitch daemon.
+spec:
+  selector:
+    matchLabels:
+      app: ovs
+  updateStrategy:
+    type: OnDelete
+  template:
+    metadata:
+      labels:
+        app: ovs
+        component: network
+        type: infra
+    spec:
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      priorityClassName: system-cluster-critical
+      serviceAccountName: ovn
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: openvswitch
+          image: "kubeovn/kube-ovn-dpdk:$DPDK_VERSION"
+          imagePullPolicy: $IMAGE_PULL_POLICY
+          command: ["/kube-ovn/start-ovs-dpdk.sh"]
+          securityContext:
+            runAsUser: 0
+            privileged: true
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: host-modules
+              readOnly: true
+            - mountPath: /var/run/openvswitch
+              name: host-run-ovs
+            - mountPath: /var/run/ovn
+              name: host-run-ovn
+            - mountPath: /sys
+              name: host-sys
+              readOnly: true
+            - mountPath: /etc/openvswitch
+              name: host-config-openvswitch
+            - mountPath: /etc/ovn
+              name: host-config-ovn
+            - mountPath: /var/log/openvswitch
+              name: host-log-ovs
+            - mountPath: /var/log/ovn
+              name: host-log-ovn
+            - mountPath: /opt/ovs-config
+              name: host-config-ovs
+            - mountPath: /dev/hugepages
+              name: hugepage
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - /kube-ovn/ovs-dpdk-healthcheck.sh
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - /kube-ovn/ovs-dpdk-healthcheck.sh
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2Gi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+              hugepages-1Gi: 1Gi
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      volumes:
+        - name: host-modules
+          hostPath:
+            path: /lib/modules
+        - name: host-run-ovs
+          hostPath:
+            path: /run/openvswitch
+        - name: host-run-ovn
+          hostPath:
+            path: /run/ovn
+        - name: host-sys
+          hostPath:
+            path: /sys
+        - name: host-config-openvswitch
+          hostPath:
+            path: /etc/origin/openvswitch
+        - name: host-config-ovn
+          hostPath:
+            path: /etc/origin/ovn
+        - name: host-log-ovs
+          hostPath:
+            path: /var/log/openvswitch
+        - name: host-log-ovn
+          hostPath:
+            path: /var/log/ovn
+        - name: host-config-ovs
+          hostPath:
+            path: /opt/ovs-config
+            type: DirectoryOrCreate
+        - name: hugepage
+          emptyDir:
+            medium: HugePages


### PR DESCRIPTION
This PR introduces the following changes to OVS-DPDK deployment:

1) Config support

Open vSwitch can be highly configured using `other_configs` options as described in [OpenvSwitch manual](http://www.openvswitch.org/support/dist-docs/ovs-vswitchd.conf.db.5.txt)).

Current deployment uses `dpdk-socket-mem="1024"` in start-ovs-dpdk.sh start script. However this approach means that OVS-DPDK can be only used on single NUMA node machines as OVS requires to allocate specific amount of hugepages for each NUMA node. So for machine with e.g. 2 NUMA nodes it should be  `dpdk-socket-mem="1024,1024"`. Therefore I've decided to create simple OVS-DPDK configuration mechanism to enable configuring OVS for multiple NUMA nodes machines (and other specific configurations) without rebuilding Docker image.

The configuration file called config.cfg is located in /opt/ovs-config on host. This directory is mounted to ovs-ovn pod. It contains list of `other_config` options (same as declared in [OpenvSwitch manual](http://www.openvswitch.org/support/dist-docs/ovs-vswitchd.conf.db.5.txt)). Each option should be placed in new line.

For example:

dpdk-socket-mem="1024,1024"
dpdk-init=true
pmd-cpu-mask=0x4
dpdk-lcore-mask=0x2
dpdk-hugepage-dir=/dev/hugepages

Will enable DPDK with 1024MB of hugepages for NUMA node 0 and NUMA node 1, PMD CPU mask 0x4, lcore mask 0x2 and hugepages in /dev/hugepages.

If file will not exist upon OVS initialization, the default configuration file will be created with values:

dpdk-socket-mem="1024"
dpdk-init=true
dpdk-hugepage-dir=/dev/hugepages

Which is the same as current configuration in start-ovs.dpdk.sh

2) Reworked start-ovs-dpdk.sh

I was testing current OVS-DPDK approach and I stumbled upon problem regarding communication between pods running on master and pods running on worker. For some reason the pods cant connect to each other.

It seems that if 'ovs-ctl restart' is used (as in start-ovs.sh) instead of 'ovs-ctl start' (as in current start-ovs-dpdk.sh) the problem does not occur. Therefore I've decided to rework 'start-ovs-dpdk.sh' to unify it with 'start-ovs.sh'.

3) Separate ovn-dpdk.yaml

As I've mentioned earlier - to enable multiple NUMA node support it's needed to request specific amount of hugepages for ovs-ovn pod. Therefore decided to introduce separate yaml that could be easily customized using kubernetes kustomize. This would ease the process of deployment on multi NUMA node machines.