### PR TITLE
Add libatomic to docker image

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -23,6 +23,7 @@ RUN yum remove -y bind-export-libs && yum update -y && \
     yum install -y \
         gnutls \
         firewalld-filesystem \
+        libatomic \
         libpcap \
         hostname ethtool \
         iproute nc \


### PR DESCRIPTION
Problem is described in #391 
In ARM64 image, ovn-central pods crashed due to missing libatomic. Resolve this problem by installing libatomic in image build steps.

