### PR TITLE
Debian: Add debian docker image support

### DIFF
--- a/dist/images/Dockerfile.debian
+++ b/dist/images/Dockerfile.debian
@@ -1,0 +1,76 @@
+# syntax = docker/dockerfile:experimental
+FROM debian:10 as ovs-builder
+
+ARG RPM_ARCH
+ARG ARCH
+
+ENV REV="buster"
+ENV SRC_DIR='/usr/src'
+
+RUN apt update && apt install build-essential git libnuma-dev autoconf curl \
+    python3 libmnl-dev libpcap-dev libtool libcap-ng-dev libssl-dev pkg-config \
+    python3-six libunbound-dev libunwind-dev dh-make fakeroot debhelper dh-python \
+    flake8 python3-sphinx graphviz groff -y 
+
+RUN cd /usr/src/ && \
+    git clone -b branch-2.14 --depth=1 https://github.com/alauda/ovs ovs && \
+    cd ovs && ./boot.sh && \
+    DATAPATH_CONFIGURE_OPTS='--prefix=/usr --disable-ssl --enable-shared' DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary 
+
+RUN cd /usr/src/ && git clone -b branch-20.06 https://github.com/alauda/ovn.git && \
+    cd ovn && \
+    curl https://github.com/alauda/ovn/commit/1aa47202c3e09f610ebefe00ab23a0723059bbf3.patch | git apply && \
+    curl https://github.com/alauda/ovn/commit/b75eb1f231da55d1b8a29f386dc56234e2eb9d35.patch | git apply && \
+    curl https://github.com/alauda/ovn/commit/7fe4df711930ac827619fe8850d56f16a1ee4d0f.patch | git apply && \
+    ./boot.sh && \
+    DATAPATH_CONFIGURE_OPTS='--prefix=/usr --with-ovs-source=/usr/src/ovs' DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary
+
+RUN mkdir /packages/ && \
+     cp /usr/src/libopenvswitch*.deb /packages && \
+     cp /usr/src/openvswitch-*.deb /packages && \
+     cp /usr/src/python3-openvswitch*.deb /packages && \
+     cp /usr/src/ovn-*.deb /packages && \
+     cd /packages && rm -f *dbg* *datapath* *docker* *vtep* *ipsec* *test* *dev*
+
+FROM debian:10
+
+ENV REV="buster"
+ARG RPM_ARCH
+
+
+RUN apt update && apt install python3 hostname libunwind8 netbase \
+        ethtool iproute2 ncat libunbound-dev procps libatomic1 kmod \
+        tcpdump ipset curl uuid-runtime libssl-dev \
+        python3-six python3-zope.interface -y
+
+RUN mkdir -p /var/run/openvswitch && \
+    mkdir -p /var/run/ovn && \
+    mkdir -p /etc/cni/net.d && \
+    mkdir -p /opt/cni/bin
+
+ARG ARCH
+ENV CNI_VERSION=v0.8.6
+RUN curl -sSf -L --retry 5 https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz | tar -xz -C . ./loopback ./portmap
+
+ENV KUBE_VERSION="v1.13.2"
+
+RUN curl -L https://dl.k8s.io/${KUBE_VERSION}/kubernetes-client-linux-${ARCH}.tar.gz | tar -xz -C . && cp ./kubernetes/client/bin/kubectl /usr/bin/kubectl \
+ && chmod +x /usr/bin/kubectl && rm -rf ./kubernetes
+
+RUN --mount=type=bind,target=/packages,from=ovs-builder,source=/packages  \
+    dpkg -i /packages/libopenvswitch*.deb && \
+    dpkg -i /packages/openvswitch-*.deb && \
+    dpkg -i /packages/python3-openvswitch*.deb &&\
+    dpkg -i /packages/ovn-*.deb && \
+    cp -f /packages/ovn-*.deb /root/
+
+COPY *.sh /kube-ovn/
+COPY 01-kube-ovn.conflist /kube-ovn/01-kube-ovn.conflist
+
+WORKDIR /kube-ovn
+
+COPY kube-ovn-speaker /kube-ovn/kube-ovn-speaker
+COPY kube-ovn-pinger /kube-ovn/kube-ovn-pinger
+COPY kube-ovn /kube-ovn/kube-ovn
+COPY kube-ovn-daemon /kube-ovn/kube-ovn-daemon
+COPY kube-ovn-controller /kube-ovn/kube-ovn-controller

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -713,14 +713,14 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovn-is-leader.sh
             periodSeconds: 3
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovn-healthcheck.sh
             initialDelaySeconds: 30
             periodSeconds: 7
@@ -895,14 +895,14 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovs-dpdk-healthcheck.sh
             periodSeconds: 5
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovs-dpdk-healthcheck.sh
             initialDelaySeconds: 10
             periodSeconds: 5
@@ -1217,14 +1217,14 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovn-is-leader.sh
             periodSeconds: 3
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovn-healthcheck.sh
             initialDelaySeconds: 30
             periodSeconds: 7
@@ -1396,14 +1396,14 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovs-healthcheck.sh
             periodSeconds: 5
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovs-healthcheck.sh
             initialDelaySeconds: 10
             periodSeconds: 5
@@ -1533,14 +1533,14 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/kube-ovn-controller-healthcheck.sh
             periodSeconds: 3
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/kube-ovn-controller-healthcheck.sh
             initialDelaySeconds: 300
             periodSeconds: 7
@@ -1603,7 +1603,7 @@ spec:
         image: "$REGISTRY/kube-ovn:$VERSION"
         imagePullPolicy: $IMAGE_PULL_POLICY
         command:
-          - sh
+          - bash
           - /kube-ovn/start-cniserver.sh
         args:
           - --enable-mirror=$ENABLE_MIRROR


### PR DESCRIPTION
Add debian docker image support, this patch works with patch in ovn repo
"debian: fix ovn debian packaging and split from openvswitch"

Also, as debian default shell is not bash, set install script cmd to
bash.