### PR TITLE
<fix>(np) fix for empty "from" filed networkpolicy

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -219,7 +219,6 @@ func (c *Controller) handleUpdateNp(key string) error {
 			if len(npr.From) == 0 {
 				allows = []string{"0.0.0.0/0"}
 				excepts = []string{}
-				break
 			} else {
 				for _, npp := range npr.From {
 					allow, except, err := c.fetchPolicySelectedAddresses(np.Namespace, npp)

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -301,7 +301,6 @@ func (c *Controller) handleUpdateNp(key string) error {
 			if len(npr.To) == 0 {
 				allows = []string{"0.0.0.0/0"}
 				excepts = []string{}
-				break
 			} else {
 				for _, npp := range npr.To {
 					allow, except, err := c.fetchPolicySelectedAddresses(np.Namespace, npp)


### PR DESCRIPTION
while np contains multi rules, and some rules only has ports filed, this rule will be skipped.