### PR TITLE
Update the container nic name use the CNI_IFNAME parameter which passed by kubelet

### DIFF
--- a/cmd/cni/cni.go
+++ b/cmd/cni/cni.go
@@ -52,6 +52,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		PodNamespace: podNamespace,
 		ContainerID:  args.ContainerID,
 		NetNs:        args.Netns,
+		IfName:       args.IfName,
 		Provider:     netConf.Provider,
 		DeviceID:     netConf.DeviceID,
 	})

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -101,8 +101,8 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 	}
 
 	if podRequest.Provider == util.OvnProvider {
-		klog.Infof("create container mac %s, ip %s, cidr %s, gw %s", macAddr, ipAddr, cidr, gw)
-		err := csh.configureNic(podRequest.PodName, podRequest.PodNamespace, podRequest.NetNs, podRequest.ContainerID, macAddr, ipAddr, gw, ingress, egress, vlanID, podRequest.DeviceID)
+		klog.Infof("create container interface %s mac %s, ip %s, cidr %s, gw %s", podRequest.IfName, macAddr, ipAddr, cidr, gw)
+		err := csh.configureNic(podRequest.PodName, podRequest.PodNamespace, podRequest.NetNs, podRequest.ContainerID, podRequest.IfName, macAddr, ipAddr, gw, ingress, egress, vlanID, podRequest.DeviceID)
 		if err != nil {
 			errMsg := fmt.Errorf("configure nic failed %v", err)
 			klog.Error(errMsg)

--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/klog"
 )
 
-func (csh cniServerHandler) configureNic(podName, podNamespace, netns, containerID, mac, ip, gateway, ingress, egress, vlanID, DeviceID string) error {
+func (csh cniServerHandler) configureNic(podName, podNamespace, netns, containerID, ifName, mac, ip, gateway, ingress, egress, vlanID, DeviceID string) error {
 	var err error
 	var hostNicName, containerNicName string
 	if DeviceID == "" {
@@ -64,7 +64,7 @@ func (csh cniServerHandler) configureNic(podName, podNamespace, netns, container
 	if err != nil {
 		return fmt.Errorf("failed to open netns %q: %v", netns, err)
 	}
-	if err = configureContainerNic(containerNicName, ip, gateway, macAddr, podNS, csh.Config.MTU); err != nil {
+	if err = configureContainerNic(containerNicName, ifName, ip, gateway, macAddr, podNS, csh.Config.MTU); err != nil {
 		return err
 	}
 	return nil
@@ -126,7 +126,7 @@ func configureHostNic(nicName, vlanID string) error {
 	return nil
 }
 
-func configureContainerNic(nicName, ipAddr, gateway string, macAddr net.HardwareAddr, netns ns.NetNS, mtu int) error {
+func configureContainerNic(nicName, ifName string, ipAddr, gateway string, macAddr net.HardwareAddr, netns ns.NetNS, mtu int) error {
 	containerLink, err := netlink.LinkByName(nicName)
 	if err != nil {
 		return fmt.Errorf("can not find container nic %s %v", nicName, err)
@@ -136,10 +136,8 @@ func configureContainerNic(nicName, ipAddr, gateway string, macAddr net.Hardware
 		return fmt.Errorf("failed to link netns %v", err)
 	}
 
-	// TODO: use github.com/containernetworking/plugins/pkg/ipam.ConfigureIface to refactor this logical
 	return ns.WithNetNSPath(netns.Path(), func(_ ns.NetNS) error {
-		// Container nic name MUST be 'eth0', otherwise kubelet will recreate the pod
-		if err = netlink.LinkSetName(containerLink, "eth0"); err != nil {
+		if err = netlink.LinkSetName(containerLink, ifName); err != nil {
 			return err
 		}
 		if util.CheckProtocol(ipAddr) == kubeovnv1.ProtocolDual || util.CheckProtocol(ipAddr) == kubeovnv1.ProtocolIPv6 {
@@ -157,7 +155,7 @@ func configureContainerNic(nicName, ipAddr, gateway string, macAddr net.Hardware
 			}
 		}
 
-		if err = configureNic("eth0", ipAddr, macAddr, mtu); err != nil {
+		if err = configureNic(ifName, ipAddr, macAddr, mtu); err != nil {
 			return err
 		}
 

--- a/pkg/request/cniserver.go
+++ b/pkg/request/cniserver.go
@@ -20,6 +20,7 @@ type CniRequest struct {
 	PodNamespace string `json:"pod_namespace"`
 	ContainerID  string `json:"container_id"`
 	NetNs        string `json:"net_ns"`
+	IfName       string `json:"if_name"`
 	Provider     string `json:"provider"`
 	// PciAddrs in case of using sriov
 	DeviceID string `json:"deviceID"`


### PR DESCRIPTION
Update the container nic name use the CNI_IFNAME parameter which passed by kubelet

The default CNI_IFNAME parameter passed by kubelet is "eth0", so we can use this.

Reference link: https://github.com/kubernetes/kubernetes/blob/88a05df5ff1b311e8e92f64b4f3a2c7d4329d14e/pkg/kubelet/dockershim/network/cni/cni.go#L398