### PR TITLE
Fix the default mtu parameter's describe

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -140,7 +140,7 @@ You can use `--default-cidr` flags below to config default Pod CIDR or create a 
       --log_file_max_size uint            Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
       --logtostderr                       log to standard error instead of files (default true)
       --mirror-iface string               The mirror nic name that will be created by kube-ovn, default: mirror0 (default "mirror0")
-      --mtu int                           The MTU used by pod iface, default: iface MTU - 55
+      --mtu int                           The MTU used by pod iface, default: iface MTU - 100
       --network-type string               The ovn network type, default: geneve (default "geneve")
       --node-local-dns-ip string          If use nodelocaldns the local dns server ip should be set here, default empty.
       --ovs-socket string                 The socket to local ovs-server

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -49,7 +49,7 @@ type Configuration struct {
 func ParseFlags() (*Configuration, error) {
 	var (
 		argIface                 = pflag.String("iface", "", "The iface used to inter-host pod communication can be a nic name or a group of regex separated by comma, default: the default route iface")
-		argMTU                   = pflag.Int("mtu", 0, "The MTU used by pod iface, default: iface MTU - 55")
+		argMTU                   = pflag.Int("mtu", 0, "The MTU used by pod iface, default: iface MTU - 100")
 		argEnableMirror          = pflag.Bool("enable-mirror", false, "Enable traffic mirror, default: false")
 		argMirrorNic             = pflag.String("mirror-iface", "mirror0", "The mirror nic name that will be created by kube-ovn, default: mirror0")
 		argBindSocket            = pflag.String("bind-socket", "/var/run/cniserver.sock", "The socket daemon bind to.")


### PR DESCRIPTION
Fix the default mtu parameter's describe.

Reference is as follows:

https://github.com/alauda/kube-ovn/blob/e7888f17048cdb8ef3fcb0c9faa55e61974f0c9f/pkg/util/const.go#L67

https://github.com/alauda/kube-ovn/blob/e7888f17048cdb8ef3fcb0c9faa55e61974f0c9f/pkg/daemon/config.go#L158-L160