### PR TITLE
Fix: replace the command to run the script via 'sh' with 'bash'

### DIFF
--- a/yamls/kube-ovn-ipv6.yaml
+++ b/yamls/kube-ovn-ipv6.yaml
@@ -68,14 +68,14 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/kube-ovn-controller-healthcheck.sh
             periodSeconds: 3
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/kube-ovn-controller-healthcheck.sh
             initialDelaySeconds: 300
             periodSeconds: 7
@@ -131,7 +131,7 @@ spec:
           image: "kubeovn/kube-ovn:v1.5.2"
           imagePullPolicy: IfNotPresent
           command:
-            - sh
+            - bash
             - /kube-ovn/start-cniserver.sh
           args:
             - --enable-mirror=false

--- a/yamls/kube-ovn.yaml
+++ b/yamls/kube-ovn.yaml
@@ -70,14 +70,14 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/kube-ovn-controller-healthcheck.sh
             periodSeconds: 3
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/kube-ovn-controller-healthcheck.sh
             initialDelaySeconds: 300
             periodSeconds: 7
@@ -140,7 +140,7 @@ spec:
           image: "kubeovn/kube-ovn:v1.5.2"
           imagePullPolicy: IfNotPresent
           command:
-            - sh
+            - bash
             - /kube-ovn/start-cniserver.sh
           args:
             - --enable-mirror=false

--- a/yamls/ovn-dpdk.yaml
+++ b/yamls/ovn-dpdk.yaml
@@ -255,14 +255,14 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovn-is-leader.sh
             periodSeconds: 3
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovn-healthcheck.sh
             initialDelaySeconds: 30
             periodSeconds: 7
@@ -433,14 +433,14 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovs-dpdk-healthcheck.sh
             periodSeconds: 5
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovs-dpdk-healthcheck.sh
             initialDelaySeconds: 10
             periodSeconds: 5

--- a/yamls/ovn-ha.yaml
+++ b/yamls/ovn-ha.yaml
@@ -238,14 +238,14 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovn-is-leader.sh
             periodSeconds: 3
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovn-healthcheck.sh
             initialDelaySeconds: 30
             periodSeconds: 7
@@ -353,14 +353,14 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovs-healthcheck.sh
             periodSeconds: 5
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovs-healthcheck.sh
             initialDelaySeconds: 10
             periodSeconds: 5

--- a/yamls/ovn.yaml
+++ b/yamls/ovn.yaml
@@ -255,14 +255,14 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovn-is-leader.sh
             periodSeconds: 3
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovn-healthcheck.sh
             initialDelaySeconds: 30
             periodSeconds: 7
@@ -432,14 +432,14 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovs-healthcheck.sh
             periodSeconds: 5
             timeoutSeconds: 45
           livenessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - /kube-ovn/ovs-healthcheck.sh
             initialDelaySeconds: 10
             periodSeconds: 5


### PR DESCRIPTION
Fix: replace the command to run the script via 'sh' with 'bash'

Although in most cases, 'sh' is a soft link to 'bash', in some special operating systems, 'sh' points to 'dash', and some scripts cannot be run through 'dash'.

It will get error if I run the shell script when I use an other base image.

```shell
root@master1:/kube-ovn# cat /kube-ovn/ovn-healthcheck.sh
#!/bin/bash
set -euo pipefail
shopt -s expand_aliases

alias ovn-ctl='/usr/share/ovn/scripts/ovn-ctl'

ovn-ctl status_northd
ovn-ctl status_ovnnb
ovn-ctl status_ovnsb
root@master1:/kube-ovn# sh /kube-ovn/ovn-healthcheck.sh
/kube-ovn/ovn-healthcheck.sh: 2: set: Illegal option -o pipefail
root@master1:/kube-ovn# 
root@master1:/kube-ovn# bash /kube-ovn/ovn-healthcheck.sh
ovn-northd is running with pid 80
running/active
running/active
root@master1:/kube-ovn# which sh
/bin/sh
root@master1:/kube-ovn# ls -l /bin/sh
lrwxrwxrwx 1 root root 4 Dec 30 08:11 /bin/sh -> dash
root@master1:/kube-ovn# 
```
