### PR TITLE
Fix wait pod network ready take long time

### DIFF
--- a/pkg/daemon/ovs.go
+++ b/pkg/daemon/ovs.go
@@ -213,8 +213,10 @@ func waitNetworkReady(gateway string) error {
 			return fmt.Errorf("failed to init pinger, %v", err)
 		}
 		pinger.SetPrivileged(true)
-		pinger.Count = 600
-		pinger.Timeout = 600 * time.Second
+		// CNITimeoutSec = 220, cannot exceed
+		count := 200
+		pinger.Count = count
+		pinger.Timeout = time.Duration(count) * time.Second
 		pinger.Interval = 1 * time.Second
 
 		success := false
@@ -226,7 +228,7 @@ func waitNetworkReady(gateway string) error {
 
 		cniConnectivityResult.WithLabelValues(nodeName).Add(float64(pinger.PacketsSent))
 		if !success {
-			return fmt.Errorf("network not ready after 600 ping")
+			return fmt.Errorf("network not ready after %d ping", count)
 		}
 		klog.Infof("network ready after %d ping, gw %v", pinger.PacketsSent, gw)
 	}


### PR DESCRIPTION
ovn-cni
```
handler.go:108] configure nic failed network not ready after 600 ping
```

kubelet
```
kubelet[31530]: E0108 07:23:45.522787   31530 remote_runtime.go:116] RunPodSandbox from runtime service failed: rpc error: code = Unknown desc = failed to set up sandbox container "bbe9f0f6ac014fe5acd07727d67e328b4a4358c09c3c93810cfa91f05e4ad0a1" network for pod "kube-ovn-pinger-2vghd": networkPlugin cni failed to set up pod "kube-ovn-pinger-2vghd_kube-system" network: netplugin failed with no error message: signal: killed
```

For cni plugin should return in 220s. 
ref https://github.com/kubernetes/kubernetes/blob/release-1.16/pkg/kubelet/dockershim/network/cni/cni.go#L310