### PR TITLE
fix: make sure northd leader change

### DIFF
--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -68,9 +68,9 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
   if [[ -z "$NODE_IPS" ]]; then
       /usr/share/ovn/scripts/ovn-ctl restart_northd
       ovn-nbctl set-connection ptcp:"${DB_NB_PORT}":["${DB_NB_ADDR}"]
-      ovn-nbctl set Connection . inactivity_probe=0
+      ovn-nbctl set Connection . inactivity_probe=180000
       ovn-sbctl set-connection ptcp:"${DB_SB_PORT}":["${DB_SB_ADDR}"]
-      ovn-sbctl set Connection . inactivity_probe=0
+      ovn-sbctl set Connection . inactivity_probe=180000
   else
       if [[ ! "$NODE_IPS" =~ "$POD_IP" ]]; then
         echo "ERROR! host ip $POD_IP not in env NODE_IPS $NODE_IPS"
@@ -93,9 +93,9 @@ if [[ "$ENABLE_SSL" == "false" ]]; then
               --ovn-northd-sb-db="$(gen_conn_str 6642)" \
               start_northd
           ovn-nbctl set-connection ptcp:"${DB_NB_PORT}":[::]
-          ovn-nbctl set Connection . inactivity_probe=0
+          ovn-nbctl set Connection . inactivity_probe=180000
           ovn-sbctl set-connection ptcp:"${DB_SB_PORT}":[::]
-          ovn-sbctl set Connection . inactivity_probe=0
+          ovn-sbctl set Connection . inactivity_probe=180000
       else
           while ! nc -z "${nb_leader_ip}" "${DB_NB_PORT}" >/dev/null;
           do
@@ -135,9 +135,9 @@ else
         --ovn-northd-ssl-ca-cert=/var/run/tls/cacert \
         restart_northd
       ovn-nbctl -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_NB_PORT}":["${DB_NB_ADDR}"]
-      ovn-nbctl -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set Connection . inactivity_probe=0
+      ovn-nbctl -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set Connection . inactivity_probe=180000
       ovn-sbctl -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_SB_PORT}":["${DB_SB_ADDR}"]
-      ovn-sbctl -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set Connection . inactivity_probe=0
+      ovn-sbctl -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set Connection . inactivity_probe=180000
   else
       if [[ ! "$NODE_IPS" =~ "$POD_IP" ]]; then
         echo "ERROR! host ip $POD_IP not in env NODE_IPS $NODE_IPS"
@@ -167,9 +167,9 @@ else
               --ovn-northd-sb-db="$(gen_conn_str 6642)" \
               start_northd
           ovn-nbctl -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_NB_PORT}":[::]
-          ovn-nbctl set Connection . inactivity_probe=0
+          ovn-nbctl set Connection . inactivity_probe=180000
           ovn-sbctl -p /var/run/tls/key -c /var/run/tls/cert -C /var/run/tls/cacert set-connection pssl:"${DB_SB_PORT}":[::]
-          ovn-sbctl set Connection . inactivity_probe=0
+          ovn-sbctl set Connection . inactivity_probe=180000
       else
           while ! nc -z "${nb_leader_ip}" "${DB_NB_PORT}" >/dev/null;
           do


### PR DESCRIPTION
When node power down, the exist connection will not be closed. If no inactivity_probe set,
the stale northd will still be the leader and all process from nb to sb will stop. Change the
inactivity_probe to 3min to fix this.