### PR TITLE
fix: check required module before start

### DIFF
--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -5,6 +5,11 @@ HW_OFFLOAD=${HW_OFFLOAD:-false}
 ENABLE_SSL=${ENABLE_SSL:-false}
 OVN_DB_IPS=${OVN_DB_IPS:-}
 
+
+# Check required kernel module
+modinfo openvswitch
+modinfo geneve
+
 # https://bugs.launchpad.net/neutron/+bug/1776778
 if grep -q "3.10.0-862" /proc/version
 then


### PR DESCRIPTION
If geneve module do not exist, cross node communication will break and ovs-vswitchd will pop the messages below

```
2021-01-19T02:20:41.920Z|00088|bridge|WARN|Dropped 7 log messages in last 9 seconds (most recently, 9 seconds ago) due to excessive rate
2021-01-19T02:20:41.920Z|00089|bridge|WARN|could not add network device ovn-faced1-0 to ofproto (Address family not supported by protocol)
2021-01-19T02:20:41.921Z|00090|dpif|WARN|system@ovs-system: failed to add ovn-92c1eb-0 as port: Address family not supported by protocol
2021-01-19T02:20:41.923Z|00091|dpif|WARN|system@ovs-system: failed to add ovn-faced1-0 as port: Address family not supported by protocol
2021-01-19T02:20:41.925Z|00092|dpif|WARN|system@ovs-system: failed to add ovn-92c1eb-0 as port: Address family not supported by protocol
```