### PR TITLE
fix underlay gateway flood logs

### DIFF
--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -578,7 +578,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		}
 	} else {
 		// logical switch exists, only update other_config
-		if err := c.ovnClient.SetLogicalSwitchConfig(subnet.Name, vpc.Status.Router, subnet.Spec.Protocol, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, subnet.Spec.ExcludeIps); err != nil {
+		if err := c.ovnClient.SetLogicalSwitchConfig(subnet.Name, subnet.Spec.UnderlayGateway, vpc.Status.Router, subnet.Spec.Protocol, subnet.Spec.CIDRBlock, subnet.Spec.Gateway, subnet.Spec.ExcludeIps); err != nil {
 			c.patchSubnetStatus(subnet, "SetLogicalSwitchConfigFailed", err.Error())
 			return err
 		}


### PR DESCRIPTION
```shell
E0114 02:45:16.898201       1 ovn-nbctl.go:182] set switch config for ovn-default failed ovn-nbctl: no row "ovn-cluster-ovn-default" in table Logical_Router_Port
, "exit status 1"
I0114 02:45:16.898312       1 event.go:282] Event(v1.ObjectReference{Kind:"Subnet", Namespace:"", Name:"ovn-default", UID:"15d87b18-d435-414e-88f3-8ff9ca8c54e2", APIVersion:"kubeovn.io/v1", ResourceVersion:"1485089", FieldPath:""}): type: 'Warning' reason: 'SetLogicalSwitchConfigFailed' ovn-nbctl: no row "ovn-cluster-ovn-default" in table Logical_Router_Port
, "exit status 1"
E0114 02:45:16.902911       1 subnet.go:152] error syncing 'ovn-default': ovn-nbctl: no row "ovn-cluster-ovn-default" in table Logical_Router_Port
, "exit status 1", requeuing
I0114 03:01:56.903089       1 subnet.go:288] format subnet ovn-default, changed false
W0114 03:01:56.926502       1 ovn-nbctl.go:26] ovn-nbctl command error or took too long
W0114 03:01:56.926518       1 ovn-nbctl.go:27] ovn-nbctl --timeout=30 --may-exist ls-add ovn-default -- set logical_switch ovn-default other_config:subnet=192.168.1.0/24 -- set logical_switch ovn-default other_config:gateway=192.168.1.1 -- set logical_switch ovn-default other_config:exclude_ips=192.168.1.1 192.168.1.2 192.168.1.3 -- set logical_router_port ovn-cluster-ovn-default networks=192.168.1.1/24 in 3ms
E0114 03:01:56.926537       1 ovn-nbctl.go:182] set switch config for ovn-default failed ovn-nbctl: no row "ovn-cluster-ovn-default" in table Logical_Router_Port
, "exit status 1"
I0114 03:01:56.926648       1 event.go:282] Event(v1.ObjectReference{Kind:"Subnet", Namespace:"", Name:"ovn-default", UID:"15d87b18-d435-414e-88f3-8ff9ca8c54e2", APIVersion:"kubeovn.io/v1", ResourceVersion:"1486917", FieldPath:""}): type: 'Warning' reason: 'SetLogicalSwitchConfigFailed' ovn-nbctl: no row "ovn-cluster-ovn-default" in table Logical_Router_Port
, "exit status 1"
E0114 03:01:56.931161       1 subnet.go:152] error syncing 'ovn-default': ovn-nbctl: no row "ovn-cluster-ovn-default" in table Logical_Router_Port
, "exit status 1", requeuing
```