### PR TITLE
Fix: wrong split in FindLoadbalancer function

### DIFF
--- a/pkg/ovs/ovn-nbctl.go
+++ b/pkg/ovs/ovn-nbctl.go
@@ -611,7 +611,7 @@ func (c Client) DeleteStaticRouteByNextHop(nextHop string) error {
 func (c Client) FindLoadbalancer(lb string) (string, error) {
 	output, err := c.ovnNbCommand("--data=bare", "--no-heading", "--columns=_uuid",
 		"find", "load_balancer", fmt.Sprintf("name=%s", lb))
-	count := len(strings.Split(output, "/n"))
+	count := len(strings.Split(output, "\n"))
 	if count > 1 {
 		klog.Errorf("%s has %d lb entries", lb, count)
 		return "", fmt.Errorf("%s has %d lb entries", lb, count)


### PR DESCRIPTION

In my env, the `kube-ovn-controller` got error as follows:

```shell
root@master1:~# kubectl logs -n kube-system kube-ovn-controller-6f79b7c4ff-n4hd9  
I0120 05:20:50.208782       1 config.go:183] no --kubeconfig, use in-cluster kubernetes config
I0120 05:20:50.213103       1 config.go:175] config is  &{BindAddress: OvnNbSocket: OvnNbHost:10.105.133.40 OvnNbPort:6641 OvnSbHost:10.105.47.245 OvnSbPort:6642 OvnTimeout:30 KubeConfigFile: KubeClient:0xc0004623c0 KubeOvnClient:0xc000402520 DefaultLogicalSwitch:ovn-default DefaultCIDR:10.101.0.0/16 DefaultGateway:10.101.0.1 DefaultExcludeIps:10.101.0.1 ClusterRouter:ovn-cluster NodeSwitch:join NodeSwitchCIDR:100.104.0.0/16 NodeSwitchGateway:100.104.0.1 ClusterTcpLoadBalancer:cluster-tcp-loadbalancer ClusterUdpLoadBalancer:cluster-udp-loadbalancer ClusterTcpSessionLoadBalancer:cluster-tcp-session-loadbalancer ClusterUdpSessionLoadBalancer:cluster-udp-session-loadbalancer PodName:kube-ovn-controller-6f79b7c4ff-n4hd9 PodNamespace:kube-system WorkerNum:3 PprofPort:10660 NetworkType:geneve DefaultProviderName:provider DefaultHostInterface: DefaultVlanName:ovn-vlan DefaultVlanRange:1,4095 DefaultVlanID:100}
I0120 05:20:50.218270       1 controller.go:256] Starting OVN controller
I0120 05:20:50.218594       1 election.go:54] waiting for becoming a leader
I0120 05:20:50.219170       1 leaderelection.go:235] attempting to acquire leader lease  kube-system/ovn-config...
I0120 05:20:50.270794       1 leaderelection.go:245] successfully acquired lease kube-system/ovn-config
I0120 05:20:50.270829       1 election.go:99] new leader elected: kube-ovn-controller-6f79b7c4ff-n4hd9
I0120 05:20:50.271068       1 election.go:77] I am the new leader
I0120 05:20:55.218808       1 controller.go:266] Waiting for informer caches to sync
I0120 05:20:55.430685       1 init.go:114] exists routers [ovn-cluster]
I0120 05:20:55.446961       1 init.go:137] tcp load balancer 4ecc2d43-468f-4fa9-9ab5-cd95a6083b39 exists
I0120 05:20:55.457620       1 init.go:152] tcp session load balancer 3e3fd658-07c7-45d5-8bc0-8605fd2755d3 exists
I0120 05:20:55.469646       1 init.go:167] udp load balancer e5cd2452-4fc2-4a4c-b025-5440c420da57 exists
I0120 05:20:55.481291       1 init.go:182] udp session load balancer f4b8f9fa-97b6-494a-aee4-be96448d3032

491a55db-d81b-478a-9084-951f998f4457 exists
I0120 05:20:55.535191       1 ipam.go:94] adding new subnet join
I0120 05:20:55.535277       1 ipam.go:94] adding new subnet ovn-default
I0120 05:20:55.535488       1 gc.go:70] start to gc nodes
I0120 05:20:55.535517       1 gc.go:37] start to gc logical switch
I0120 05:20:55.553747       1 gc.go:52] ls in ovn []
I0120 05:20:55.553787       1 gc.go:53] subnet in kubernetes [join ovn-default]
I0120 05:20:55.553828       1 gc.go:104] start to gc logical switch port
I0120 05:20:58.587450       1 gc.go:165] start to gc loadbalancers
W0120 05:20:58.911455       1 ovn-nbctl.go:24] ovn-nbctl command error or took too long
W0120 05:20:58.911492       1 ovn-nbctl.go:25] ovn-nbctl --timeout=30 --data=bare --no-heading get load_balancer f4b8f9fa-97b6-494a-aee4-be96448d3032

491a55db-d81b-478a-9084-951f998f4457 vips in 20ms
E0120 05:20:58.911565       1 gc.go:259] failed to get udp session lb vips ovn-nbctl: no row "f4b8f9fa-97b6-494a-aee4-be96448d3032

491a55db-d81b-478a-9084-951f998f4457" in table Load_Balancer
, "exit status 1"
F0120 05:20:58.911590       1 controller.go:281] gc failed ovn-nbctl: no row "f4b8f9fa-97b6-494a-aee4-be96448d3032

491a55db-d81b-478a-9084-951f998f4457" in table Load_Balancer
, "exit status 1"
```

I executed the following command by manual:

```shell
[root@master1 kube-ovn]# ovn-nbctl --timeout=30 --data=bare --no-heading  --columns=_uuid find load_balancer name=cluster-udp-session-loadbalancer
f4b8f9fa-97b6-494a-aee4-be96448d3032

491a55db-d81b-478a-9084-951f998f4457
```

I got two pieces of data, and I checked the source code, I found the split was wrong.

Despite this, I still can’t figure out why there are two pieces of data. I didn't see the problem that may cause multiple creation in the initialization place. 
