### PR TITLE
fix: reset ovn0 addr

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -201,8 +201,9 @@ func (c *Controller) handleAddNode(key string) error {
 
 	var v4IP, v6IP, mac string
 	portName := fmt.Sprintf("node-%s", key)
-	if node.Annotations[util.AllocatedAnnotation] == "true" {
-		return nil
+	if node.Annotations[util.IpAddressAnnotation] != "" && node.Annotations[util.MacAddressAnnotation] != "" {
+		v4IP, v6IP = util.SplitStringIP(node.Annotations[util.IpAddressAnnotation])
+		mac = node.Annotations[util.MacAddressAnnotation]
 	} else {
 		v4IP, v6IP, mac, err = c.ipam.GetRandomAddress(portName, c.config.NodeSwitch)
 		if err != nil {

--- a/test/e2e/ip/static_ip.go
+++ b/test/e2e/ip/static_ip.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	TestImage =  "kubeovn/pause:3.2"
+	TestImage = "kubeovn/pause:3.2"
 )
+
 var _ = Describe("[IP Allocation]", func() {
 	namespace := "static-ip"
 	f := framework.NewFramework("ip allocation", fmt.Sprintf("%s/.kube/config", os.Getenv("HOME")))


### PR DESCRIPTION
Users may clean up kube-ovn but without cleanup the node annotations and reinstall kube-ovn. 
The old node ovn0 addresses are different from the new ones.
As node number is unlikely to a great amount, so we reset the ovn0 port every time the controller restart to prevent some weird incident